### PR TITLE
fix: remove type from identity object

### DIFF
--- a/src/runtime/nuxt/plugin/defaults.ts
+++ b/src/runtime/nuxt/plugin/defaults.ts
@@ -41,6 +41,9 @@ export default defineNuxtPlugin({
       if (typeof identity !== 'string') {
         identityPayload = defu(identity, identityPayload)
         identityType = identity.type
+
+        // Remove type from object to avoid invalid markup
+        delete identity.type;
       }
       else {
         identityType = identity


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This is a small PR to remove the `type` property from the `identity` object created in the `nuxt.config.ts`. I got an error from [ahrefs.com](ahrefs.com) about "Invalid [schema.org](https://schema.org/) property." since `type` is not a valid property within the Identity object.
