### PR TITLE
docs: remove `nuxt.config` section in Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,10 @@ The quickest and easiest way to build Schema.org graphs for Nuxt. Powered by [Un
 
 ## Installation
 
-1. Install `nuxt-schema-org` dependency to your project:
+Install `nuxt-schema-org` dependency to your project:
 
 ```bash
 npx nuxi@latest module add schema-org
-```
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ['nuxt-schema-org']
-})
 ```
 
 # Documentation


### PR DESCRIPTION
### Description

`nuxi module add` section has been added for `nuxt-schema-org` in #50 issue.

nuxt.config is automatically added by Nuxi, so I removed (2).

### Linked Issues

related #50 .

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
