### PR TITLE
fix: do not try to access private runtime config on client

### DIFF
--- a/src/runtime/nitro/routes/__schema-org__/debug.ts
+++ b/src/runtime/nitro/routes/__schema-org__/debug.ts
@@ -3,7 +3,8 @@ import type { ModuleRuntimeConfig } from '../../../types'
 import { useNitroOrigin, useRuntimeConfig } from '#imports'
 
 export default defineEventHandler(async (e) => {
-  const runtimeConfig = (useRuntimeConfig()['nuxt-schema-org'] || useRuntimeConfig().public['nuxt-schema-org']) as any as ModuleRuntimeConfig
+  const _config = useRuntimeConfig()
+  const runtimeConfig = (import.meta.client ? _config.public['nuxt-schema-org'] : (_config['nuxt-schema-org'] || _config.public['nuxt-schema-org'])) as any as ModuleRuntimeConfig
   const nitroOrigin = useNitroOrigin(e)
   return {
     nitroOrigin,

--- a/src/runtime/nuxt/imports/useSchemaOrg.ts
+++ b/src/runtime/nuxt/imports/useSchemaOrg.ts
@@ -5,7 +5,8 @@ import { useHead, useRuntimeConfig, useServerHead } from '#imports'
 
 type Input = Parameters<typeof _useSchemaOrg>[0]
 export function useSchemaOrg<T extends Input>(input: T): ActiveHeadEntry<UnheadAugmentation<T>> | void {
-  const config = (useRuntimeConfig()['nuxt-schema-org'] || useRuntimeConfig().public['nuxt-schema-org']) as ModuleRuntimeConfig
+  const _config = useRuntimeConfig()
+  const config = (import.meta.client ? _config.public['nuxt-schema-org'] : (_config['nuxt-schema-org'] || _config.public['nuxt-schema-org'])) as ModuleRuntimeConfig
   const script = {
     type: 'application/ld+json',
     key: 'schema-org-graph',

--- a/src/runtime/nuxt/plugin/defaults.ts
+++ b/src/runtime/nuxt/plugin/defaults.ts
@@ -14,7 +14,8 @@ import {
 export default defineNuxtPlugin({
   name: 'nuxt-schema-org:defaults',
   setup() {
-    const runtimeConfig = useRuntimeConfig()['nuxt-schema-org'] || useRuntimeConfig().public['nuxt-schema-org']
+    const _config = useRuntimeConfig()
+    const runtimeConfig = import.meta.client ? _config.public['nuxt-schema-org'] : (_config['nuxt-schema-org'] || _config.public['nuxt-schema-org'])
     // get the head instance
     const siteConfig = useSiteConfig()
 

--- a/src/runtime/nuxt/plugin/init.ts
+++ b/src/runtime/nuxt/plugin/init.ts
@@ -10,7 +10,8 @@ export default defineNuxtPlugin({
   enforce: 'post',
   setup(nuxtApp) {
     const head = injectHead()
-    const config = (useRuntimeConfig()['nuxt-schema-org'] || useRuntimeConfig().public['nuxt-schema-org']) as ModuleRuntimeConfig
+    const _config = useRuntimeConfig()
+    const config = (import.meta.client ? _config.public['nuxt-schema-org'] : (_config['nuxt-schema-org'] || _config.public['nuxt-schema-org'])) as ModuleRuntimeConfig
     const route = useRoute()
 
     const siteConfig = useSiteConfig()


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

resolves https://github.com/harlan-zw/nuxt-schema-org/issues/54
https://github.com/nuxt/nuxt/issues/27555

We now log (in dev mode only) when users try to access private runtime config on the client.

This ensures we don't try to do that in this module.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
