### PR TITLE
fix: correct translationOfWork reference

### DIFF
--- a/src/runtime/app/plugins/i18n/defaults.ts
+++ b/src/runtime/app/plugins/i18n/defaults.ts
@@ -53,7 +53,7 @@ export default defineNuxtPlugin({
       if (siteConfig.currentLocale && siteConfig.currentLocale !== siteConfig.defaultLocale) {
         website.translationOfWork = {
           '@type': 'WebSite',
-          '@id': `${resolveIdForLocale({ code: siteConfig.currentLocale })}#website`,
+          '@id': `${resolveIdForLocale({ code: siteConfig.defaultLocale })}#website`,
         }
       }
       else {

--- a/test/integration/i18n/basic.test.ts
+++ b/test/integration/i18n/basic.test.ts
@@ -81,7 +81,7 @@ describe('pages', () => {
               "@id": "https://nuxtseo.com/#identity",
             },
             "translationOfWork": {
-              "@id": "https://nuxtseo.com/ja#website",
+              "@id": "https://nuxtseo.com/en#website",
             },
             "url": "https://nuxtseo.com/ja",
           },


### PR DESCRIPTION

### Description

The default behaviour of the i18n integration links additional locales as translations of the default locale using `workTranslation` and `translationOfWork`. However, currently, the secondary locales link to themselves. To reciprocate `workTranslation`, they should reference the default locale.

```mermaid
graph TB

subgraph After
direction LR
en2[en] --workTranslation--> ja2[ja] & zh2[zh]  --translationOfWork--> en2
end

subgraph Before
direction LR
en --workTranslation--> ja & zh
ja --translationOfWork-->ja
zh --translationOfWork--> zh
end
```