### PR TITLE
Update unhead link in nodes.md

### DIFF
--- a/docs/content/2.guides/2.nodes.md
+++ b/docs/content/2.guides/2.nodes.md
@@ -3,7 +3,7 @@ title: Supported Nodes
 description: The nodes available for Nuxt Schema.org.
 ---
 
-The module exposes the officially supported nodes from [Unhead Schema.org](https://unhead.unjs.io/docs/typescript/schema-org/guides/core-concepts/nodes). Official nodes
+The module exposes the officially supported nodes from [Unhead Schema.org](https://unhead.unjs.io/docs/nuxt/schema-org/guides/core-concepts/nodes). Official nodes
 are ones that have a direct impact on Google Rich Results.
 
 ## Custom Nodes

--- a/docs/content/2.guides/2.nodes.md
+++ b/docs/content/2.guides/2.nodes.md
@@ -3,7 +3,7 @@ title: Supported Nodes
 description: The nodes available for Nuxt Schema.org.
 ---
 
-The module exposes the officially supported nodes from [Unhead Schema.org](https://unhead.unjs.io/schema-org/schema). Official nodes
+The module exposes the officially supported nodes from [Unhead Schema.org](https://unhead.unjs.io/docs/typescript/schema-org/guides/core-concepts/nodes). Official nodes
 are ones that have a direct impact on Google Rich Results.
 
 ## Custom Nodes


### PR DESCRIPTION
I updated only one link, others are generated through `:SchemaOrgNodeList{}` but I didn't get where it's defined. If directed towards the source, I'd be happy to amend the PR.