### PR TITLE
docs: fix wrong descriptions and add schema validator links

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -22,3 +22,7 @@ New to Schema.org? Check out the [Schema.org](/learn/mastering-meta/schema-org) 
 - 💡 Simple global meta provides for minimal boilerplate
 - 🌳 Minimal code, optimised for tree-shaking and SSR
 - Nuxt Dev Tools integration
+
+::callout{icon="i-heroicons-code-bracket" to="/tools/schema-validator"}
+**Validate your structured data** - Use our free [Schema.org Validator](/tools/schema-validator) to test JSON-LD markup and find errors.
+::

--- a/docs/content/0.getting-started/3.troubleshooting.md
+++ b/docs/content/0.getting-started/3.troubleshooting.md
@@ -27,6 +27,10 @@ You can test your Schema.org using the following tools:
 - [Google Rich Results Test](https://search.google.com/test/rich-results)
 - [Schema.org Validator](https://validator.schema.org/)
 
+## Debugging Tools
+
+- [Schema.org Validator](/tools/schema-validator) - Validate JSON-LD and Microdata markup, find errors, and ensure proper implementation for rich snippets
+
 ## Submitting an Issue
 
 When submitting an issue, it's important to provide as much information as possible.

--- a/docs/content/2.guides/0.how-it-works.md
+++ b/docs/content/2.guides/0.how-it-works.md
@@ -29,3 +29,7 @@ If you really need this behavior you can enable the `reactive` module config.
 To avoid much of the boilerplate associated with schema.org, Nuxt Schema.org will infer data from your pages.
 
 For example, it will infer data from your head tags such as `title`, `description`, `keywords`, `author`, `date`, `image`, etc.
+
+::callout{icon="i-heroicons-eye" to="/tools/schema-validator"}
+**See your output** - Use our [Schema.org Validator](/tools/schema-validator) to inspect the generated structured data on your pages.
+::

--- a/docs/content/2.guides/1.default-schema-org.md
+++ b/docs/content/2.guides/1.default-schema-org.md
@@ -96,6 +96,10 @@ export default defineNuxtConfig({
 })
 ```
 
+::callout{icon="i-heroicons-document-magnifying-glass" to="/tools/schema-validator"}
+**Check default nodes** - Validate your WebPage and WebSite schema with our [Schema.org Validator](/tools/schema-validator).
+::
+
 ## Configuring Identity
 
 Please see the [Setup Identity](/docs/schema-org/guides/setup-identity) guide for more information on configuring your identity.

--- a/docs/content/2.guides/1.setup-identity.md
+++ b/docs/content/2.guides/1.setup-identity.md
@@ -555,6 +555,10 @@ export default defineNuxtConfig({
 
 ::
 
+::callout{icon="i-heroicons-check-circle" to="/tools/schema-validator"}
+**Verify your identity** - Check your Organization or Person schema is correct with our [Schema.org Validator](/tools/schema-validator).
+::
+
 ## Recipes
 
 It's recommended to provide as much information about your identity as possible, here are some recipes.

--- a/docs/content/2.guides/2.i18n.md
+++ b/docs/content/2.guides/2.i18n.md
@@ -3,7 +3,7 @@ title: Nuxt I18n
 description: How to use the Nuxt Schema.org module with Nuxt I18n.
 ---
 
-### I18n Defaults
+## I18n Defaults
 
 When using the [defaults](/docs/schema-org/api/config#defaults) configuration, the module will automatically integrate with Nuxt I18n.
 

--- a/docs/content/2.guides/3.full-documentation.md
+++ b/docs/content/2.guides/3.full-documentation.md
@@ -1,5 +1,6 @@
 ---
 title: Full Documentation
+description: Links to the full unhead-schema-org documentation for advanced usage.
 ---
 
 The Nuxt Schema.org package is a simple wrapper around [Unhead Schema.org](https://unhead.unjs.io/schema-org/recipes/identity), you should consult

--- a/docs/content/4.api/0.config.md
+++ b/docs/content/4.api/0.config.md
@@ -1,6 +1,6 @@
 ---
 title: Nuxt Config
-description: Configure the sitemap module.
+description: Configure the Nuxt Schema.org module.
 ---
 
 ## `identity`

--- a/docs/content/4.api/0.use-schema-org.md
+++ b/docs/content/4.api/0.use-schema-org.md
@@ -1,6 +1,6 @@
 ---
 title: useSchemaOrg()
-description: A reactive way to access and set the robots rule.
+description: Define Schema.org structured data for your pages using the useSchemaOrg composable.
 ---
 
 ## Introduction

--- a/docs/content/4.releases/4.v4.md
+++ b/docs/content/4.releases/4.v4.md
@@ -5,7 +5,7 @@ description: Release notes for v4.0.0 of Nuxt Schema.org.
 
 ## Introduction
 
-The v5 major of Nuxt Schema.org is a simple release to remove deprecations and add support for the [Nuxt SEO v2 stable](https://nuxtseo.com/announcement).
+The v4 major of Nuxt Schema.org is a simple release to remove deprecations and add support for the [Nuxt SEO v2 stable](https://nuxtseo.com/announcement).
 
 ## :icon{name="i-noto-warning"} Breaking Features
 


### PR DESCRIPTION
## Summary
- Fix config.md description (was "Configure the sitemap module")
- Fix use-schema-org.md description (was "access the robots rule")
- Add missing description to full-documentation.md
- Fix heading level in i18n.md (### to ##)
- Fix v4.md intro text (said "v5 major")
- Add Schema.org Validator callouts throughout docs

## Test plan
- [ ] Verify docs render correctly on the documentation site
- [ ] Check that Schema.org Validator links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)