### PR TITLE
docs: fix internal links to use correct paths

### DIFF
--- a/docs/content/0.getting-started/0.introduction.md
+++ b/docs/content/0.getting-started/0.introduction.md
@@ -9,7 +9,7 @@ Nuxt Schema.org automatically generates JSON-LD structured data for your pages, 
 
 Rich snippets can increase click-through rates by up to 30% and provide users with more information before they visit your site.
 
-New to Schema.org? Check out the [Schema.org](/learn/mastering-meta/schema-org) guide to learn more.
+New to Schema.org? Check out the [Schema.org](/learn-seo/nuxt/mastering-meta/schema-org) guide to learn more.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Update `/learn/` links to `/learn-seo/nuxt/`

These links were causing unnecessary redirects on nuxtseo.com.

🤖 Generated with [Claude Code](https://claude.ai/code)