### PR TITLE
feat(content): add `defineSchemaOrgSchema()` composable

### DIFF
--- a/docs/content/2.guides/1.content.md
+++ b/docs/content/2.guides/1.content.md
@@ -12,21 +12,22 @@ You can see a demo of this integration in the [Nuxt OG Image & Nuxt Content Play
 
 ## Setup Nuxt Content v3
 
-In Nuxt Content v3 we need to use the `asSchemaOrgCollection()`{lang="ts"} function to augment any collections
-to be able to use the `schemaOrg` frontmatter key.
+Add `defineSchemaOrgSchema()`{lang="ts"} to your collection's schema to enable the `schemaOrg` frontmatter key.
 
 ```ts [content.config.ts]
 import { defineCollection, defineContentConfig } from '@nuxt/content'
-import { asSchemaOrgCollection } from 'nuxt-schema-org/content'
+import { defineSchemaOrgSchema } from 'nuxt-schema-org/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {
-    content: defineCollection(
-      asSchemaOrgCollection({
-        type: 'page',
-        source: '**/*.md',
+    content: defineCollection({
+      type: 'page',
+      source: '**/*.md',
+      schema: z.object({
+        schemaOrg: defineSchemaOrgSchema(),
       }),
-    ),
+    }),
   },
 })
 ```

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,9 +1,47 @@
 import type { Collection } from '@nuxt/content'
 import { z } from 'zod'
 
-const SchemaOrgNode = z.record(z.string(), z.any())
+function buildSchemaOrgObjectSchema(_z: typeof z) {
+  const node = _z.record(_z.string(), _z.any())
+  return _z.union([node, _z.array(node).optional()]).optional()
+}
 
-export const schemaOrgSchema = z.union([SchemaOrgNode, z.array(SchemaOrgNode).optional()]).optional()
+const schemaOrgObjectSchema = buildSchemaOrgObjectSchema(z)
+
+function withEditorHidden<T extends z.ZodTypeAny>(s: T): T {
+  // .editor() is patched onto ZodType by @nuxt/content at runtime
+  if (typeof (s as any).editor === 'function')
+    return (s as any).editor({ hidden: true })
+  return s
+}
+
+export interface DefineSchemaOrgSchemaOptions {
+  /**
+   * Pass the `z` instance from `@nuxt/content` to ensure `.editor({ hidden: true })` works
+   * across Zod versions. When omitted, the bundled `z` is used (`.editor()` applied if available).
+   */
+  z?: typeof z
+}
+
+/**
+ * Define the schemaOrg schema field for a Nuxt Content collection.
+ *
+ * @example
+ * defineCollection({
+ *   type: 'page',
+ *   source: '**',
+ *   schema: z.object({
+ *     schemaOrg: defineSchemaOrgSchema()
+ *   })
+ * })
+ */
+export function defineSchemaOrgSchema(options?: DefineSchemaOrgSchemaOptions) {
+  const s = options?.z ? buildSchemaOrgObjectSchema(options.z) : schemaOrgObjectSchema
+  return withEditorHidden(s)
+}
+
+// Legacy exports
+export const schemaOrgSchema = withEditorHidden(schemaOrgObjectSchema)
 
 export const schema = z.object({
   schemaOrg: schemaOrgSchema,
@@ -16,7 +54,9 @@ const headSchema = z.object({
   }).optional(),
 })
 
+/** @deprecated Use `defineSchemaOrgSchema()` in your collection schema instead. See https://nuxtseo.com/schema-org/guides/content */
 export function asSchemaOrgCollection<T>(collection: Collection<T>): Collection<T> {
+  console.warn('[schema-org] `asSchemaOrgCollection()` is deprecated. Use `defineSchemaOrgSchema()` in your collection schema instead. See https://nuxtseo.com/schema-org/guides/content')
   if (collection.type === 'page') {
     // @ts-expect-error untyped
     collection.schema = collection.schema ? schema.extend(collection.schema.shape) : schema

--- a/test/fixtures/content-v3/content.config.ts
+++ b/test/fixtures/content-v3/content.config.ts
@@ -1,17 +1,16 @@
 import { defineCollection, defineContentConfig } from '@nuxt/content'
 import { z } from 'zod'
-import { asSchemaOrgCollection } from '../../../src/content'
+import { defineSchemaOrgSchema } from '../../../src/content'
 
 export default defineContentConfig({
   collections: {
-    content: defineCollection(
-      asSchemaOrgCollection({
-        type: 'page',
-        source: '**/*.md',
-        schema: z.object({
-          date: z.string().optional(),
-        }),
+    content: defineCollection({
+      type: 'page',
+      source: '**/*.md',
+      schema: z.object({
+        date: z.string().optional(),
+        schemaOrg: defineSchemaOrgSchema(),
       }),
-    ),
+    }),
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

Related to #94

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `asSchemaOrgCollection()` wrapper mutates the collection object and depends on schema merge ordering, which can cause issues with Nuxt Content (e.g. Nuxt Studio showing injected fields, conflict detection).

`defineSchemaOrgSchema()` is a new composable that returns the schema field directly for users to compose into their own `schema: z.object()`. It accepts an optional `z` parameter so users can pass the `@nuxt/content` patched Zod instance, ensuring `.editor({ hidden: true })` works across Zod versions.

`asSchemaOrgCollection()` is kept but marked `@deprecated`.

Mirrors the same migration done in nuxt-modules/sitemap#576.