### PR TITLE
fix: align @unhead/schema-org major with host unhead (#114)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,19 @@ permissions:
 jobs:
   ci:
     uses: harlan-zw/nuxt-seo/.github/workflows/reusable-ci.yml@main
+
+  # Regression guard for #114: the module ships both @unhead/schema-org majors and
+  # must alias to the one matching the host's unhead. The main suite runs on the
+  # unhead v3 stack, so it can't catch a v3-schema-org / v2-unhead skew. This job
+  # builds + packs the module and installs it into an isolated unhead v2 host.
+  compat-v2:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: pnpm
+      - run: pnpm i
+      - run: pnpm test:compat-v2

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "test:attw": "attw --pack"
   },
   "peerDependencies": {
-    "@unhead/schema-org": "^2.0.7 || ^3.0.0",
     "@unhead/vue": "^2.0.7 || ^3.0.0",
     "unhead": "^2.0.7 || ^3.0.0",
     "zod": ">=3"
@@ -81,6 +80,8 @@
   },
   "dependencies": {
     "@nuxt/kit": "catalog:",
+    "@unhead/schema-org": "catalog:",
+    "@unhead/schema-org-v2": "catalog:",
     "defu": "catalog:",
     "nuxt-site-config": "catalog:",
     "nuxtseo-shared": "catalog:",
@@ -98,7 +99,6 @@
     "@nuxt/ui": "catalog:",
     "@nuxtjs/i18n": "catalog:",
     "@nuxtjs/robots": "catalog:",
-    "@unhead/schema-org": "catalog:",
     "@vue/test-utils": "catalog:",
     "better-sqlite3": "catalog:",
     "bumpp": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     '@unhead/schema-org':
       specifier: ^3.1.3
       version: 3.1.3
+    '@unhead/schema-org-v2':
+      specifier: npm:@unhead/schema-org@^2.1.15
+      version: 2.1.15
     '@vue/test-utils':
       specifier: ^2.4.11
       version: 2.4.11
@@ -112,6 +115,12 @@ importers:
       '@nuxt/kit':
         specifier: 'catalog:'
         version: 4.4.7(magicast@0.5.2)
+      '@unhead/schema-org':
+        specifier: 'catalog:'
+        version: 3.1.3(@unhead/vue@3.1.3(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vite@8.0.1)(vue@3.5.35(typescript@6.0.3)))(vite@8.0.1)
+      '@unhead/schema-org-v2':
+        specifier: 'catalog:'
+        version: '@unhead/schema-org@2.1.15(@unhead/vue@3.1.3(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vite@8.0.1)(vue@3.5.35(typescript@6.0.3)))(vite@8.0.1)'
       '@unhead/vue':
         specifier: ^3.1.3
         version: 3.1.3(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vite@8.0.1)(vue@3.5.35(typescript@6.0.3))
@@ -167,9 +176,6 @@ importers:
       '@nuxtjs/robots':
         specifier: 'catalog:'
         version: 6.0.9(@nuxt/schema@4.4.7)(magicast@0.5.2)(nuxt@4.4.7(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vitejs/devtools@0.1.3)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup@4.61.1))(rollup@4.61.1)(terser@5.46.1)(typescript@6.0.3)(vite@8.0.1)(yaml@2.9.0))(vite@8.0.1)(vue@3.5.35(typescript@6.0.3))(zod@4.3.6)
-      '@unhead/schema-org':
-        specifier: 'catalog:'
-        version: 3.1.3(@unhead/vue@3.1.3(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vite@8.0.1)(vue@3.5.35(typescript@6.0.3)))(vite@8.0.1)
       '@vue/test-utils':
         specifier: 'catalog:'
         version: 2.4.11(@vue/compiler-dom@3.5.35)(@vue/server-renderer@3.5.35(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3))
@@ -4056,6 +4062,23 @@ packages:
       vite:
         optional: true
       webpack:
+        optional: true
+
+  '@unhead/schema-org@2.1.15':
+    resolution: {integrity: sha512-6nfg+9CH69YHjzmjNsPjMbGylq00AAN4cYIESMy78KPhMgM35DqQHxHn5S7mNQozTfwU95V5IwHYG8i827h0xA==}
+    peerDependencies:
+      '@unhead/react': ^2.1.15
+      '@unhead/solid-js': ^2.1.15
+      '@unhead/svelte': ^2.1.15
+      '@unhead/vue': ^3.1.3
+    peerDependenciesMeta:
+      '@unhead/react':
+        optional: true
+      '@unhead/solid-js':
+        optional: true
+      '@unhead/svelte':
+        optional: true
+      '@unhead/vue':
         optional: true
 
   '@unhead/schema-org@3.1.3':
@@ -13298,6 +13321,15 @@ snapshots:
       - crossws
       - typescript
       - utf-8-validate
+
+  '@unhead/schema-org@2.1.15(@unhead/vue@3.1.3(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vite@8.0.1)(vue@3.5.35(typescript@6.0.3)))(vite@8.0.1)':
+    dependencies:
+      ufo: 1.6.4
+      unhead: 3.1.3(vite@8.0.1)
+    optionalDependencies:
+      '@unhead/vue': 3.1.3(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vite@8.0.1)(vue@3.5.35(typescript@6.0.3))
+    transitivePeerDependencies:
+      - vite
 
   '@unhead/schema-org@3.1.3(@unhead/vue@3.1.3(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.3)(vite@8.0.1)(vue@3.5.35(typescript@6.0.3)))(vite@8.0.1)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   '@nuxtjs/i18n': ^10.4.0
   '@nuxtjs/robots': ^6.0.9
   '@unhead/schema-org': ^3.1.3
+  '@unhead/schema-org-v2': npm:@unhead/schema-org@^2.1.15
   '@vue/test-utils': ^2.4.11
   better-sqlite3: ^12.10.0
   bumpp: ^11.1.0

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,13 +13,12 @@ import {
   hasNuxtModule,
   useLogger,
 } from '@nuxt/kit'
-import { defineWebPage } from '@unhead/schema-org'
-import { schemaOrgAutoImports, schemaOrgComponents } from '@unhead/schema-org/vue'
 import { defu } from 'defu'
 import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
 import { readPackageJSON } from 'pkg-types'
 import { setupDevToolsUI } from './devtools'
 import { extendTypes, resolveNuxtContentVersion } from './kit'
+import { resolveHostUnheadMajor, schemaOrgVendor } from './unhead-compat'
 
 type SchemaOrgScriptAttributes = Partial<Script> & Record<string, unknown>
 
@@ -114,6 +113,24 @@ export default defineNuxtModule<ModuleOptions>({
     }
     if (!nuxt.options.ssr && nuxt.options.dev)
       logger.warn('You are using Schema.org with SSR disabled. This is not recommended, Google may not detect your Schema.org, and it adds extra page weight')
+
+    // Pin `@unhead/schema-org` to the major matching the host's unhead. Pairing
+    // schema-org v3 with unhead v2 (e.g. current Nuxt) crashes during head
+    // resolution; we vendor both majors and alias to the compatible one. See #114.
+    const unheadMajor = await resolveHostUnheadMajor(nuxt.options.rootDir)
+    const vendor = schemaOrgVendor(unheadMajor)
+    const { defineWebPage } = await import(vendor.main) as typeof import('@unhead/schema-org')
+    const { schemaOrgAutoImports, schemaOrgComponents } = await import(vendor.vue) as typeof import('@unhead/schema-org/vue')
+    if (vendor.main !== '@unhead/schema-org') {
+      // redirect every `@unhead/schema-org` import (bundler + nitro) to the
+      // aliased v2 copy; substring replacement keeps subpaths like `/vue` intact.
+      logger.debug(`Detected unhead v${unheadMajor}, aliasing @unhead/schema-org -> ${vendor.main}`)
+      nuxt.options.alias['@unhead/schema-org'] = vendor.main
+      nuxt.hooks.hook('nitro:config', (nitroConfig) => {
+        nitroConfig.alias = nitroConfig.alias || {}
+        nitroConfig.alias['@unhead/schema-org'] = vendor.main
+      })
+    }
 
     await installNuxtSiteConfig()
 

--- a/src/unhead-compat.ts
+++ b/src/unhead-compat.ts
@@ -1,0 +1,44 @@
+import { readPackageJSON } from 'pkg-types'
+
+export type UnheadMajor = 2 | 3
+
+/**
+ * `@unhead/schema-org` attaches an object `_resolver` to every graph node. Unhead
+ * v3's `walkResolver` skips that key, but v2's walks into it and invokes the
+ * resolver's `resolve()` method as an argument-less thunk, crashing with
+ * "Cannot read properties of undefined (reading 'potentialAction')" (#114).
+ *
+ * Empirically schema-org v2 renders cleanly on unhead v2, and schema-org v3 on
+ * unhead v3. So we ship both majors (`@unhead/schema-org` + the aliased
+ * `@unhead/schema-org-v2`) and select the one matching the host's unhead.
+ *
+ * Returns the major of the unhead the host app renders with, falling back to the
+ * module's primary major (3) when it can't be resolved.
+ */
+export async function resolveHostUnheadMajor(rootDir: string): Promise<UnheadMajor> {
+  const url = rootDir.endsWith('/') ? rootDir : `${rootDir}/`
+  // `@unhead/vue` is what schema-org actually peer-depends on; fall back to the
+  // core `unhead` package when it isn't directly resolvable.
+  for (const id of ['@unhead/vue', 'unhead']) {
+    const version = await readPackageJSON(id, { url }).then(pkg => pkg.version).catch(() => {
+      // an unresolvable package is an expected miss (it just isn't installed under
+      // this id); fall through to the next candidate, then the default major.
+      return undefined
+    })
+    const major = version ? Number.parseInt(version, 10) : Number.NaN
+    if (major === 2)
+      return 2
+    if (Number.isFinite(major) && major >= 3)
+      return 3
+  }
+  return 3
+}
+
+/**
+ * Package specifiers for the vendored schema-org major matching the host unhead.
+ * The aliased `@unhead/schema-org-v2` resolves to `@unhead/schema-org@2`.
+ */
+export function schemaOrgVendor(major: UnheadMajor): { main: string, vue: string } {
+  const pkg = major === 2 ? '@unhead/schema-org-v2' : '@unhead/schema-org'
+  return { main: pkg, vue: `${pkg}/vue` }
+}

--- a/test/compat-v2/README.md
+++ b/test/compat-v2/README.md
@@ -6,10 +6,14 @@ guards the **v2** stack, which can't coexist in the same workspace because the
 unhead major is global.
 
 It is a standalone npm project (excluded from the pnpm workspace) that installs a
-coherent v2 stack — Nuxt 4.2, `@unhead/vue@2`, `unhead@2`, `@unhead/schema-org@2` —
-and links the local module via `file:../..`. The test asserts the module's
-cross-major code paths resolve correctly on unhead v2 core: the feature-detected
-plugin export, the `defineX` identity resolver, and the computed-ref node handling.
+v2 host — Nuxt 4.2, `@unhead/vue@2`, `unhead@2` — and links the local module via
+`file:../..`. It deliberately does **not** pin `@unhead/schema-org`: the module
+ships both majors, and on a v2 host its own (hoisted v3) copy would crash head
+resolution (#114) unless the module aliases `@unhead/schema-org` to the v2 copy.
+
+A successful render proves the alias works, and asserts the module's cross-major
+code paths resolve on unhead v2 core: the feature-detected plugin export, the
+`defineX` identity resolver, and the computed-ref node handling.
 
 ## Run
 

--- a/test/compat-v2/package.template.json
+++ b/test/compat-v2/package.template.json
@@ -2,7 +2,7 @@
   "name": "compat-v2",
   "private": true,
   "type": "module",
-  "description": "Isolated install pinning the Unhead v2 stack (Nuxt 4.2 / @unhead/vue@2 / @unhead/schema-org@2) to guard cross-major support. Copied to package.json by the `test:compat-v2` script and installed with npm, so it stays out of the pnpm workspace + catalog.",
+  "description": "Isolated install on the Unhead v2 stack (Nuxt 4.2 / @unhead/vue@2 / unhead@2). It deliberately does NOT pin @unhead/schema-org: the module ships both majors and must alias to the v2 copy on a v2 host, otherwise its hoisted v3 copy crashes head resolution (#114). Copied to package.json by the `test:compat-v2` script and installed with npm, so it stays out of the pnpm workspace + catalog.",
   "scripts": {
     "test": "vitest run"
   },
@@ -10,8 +10,7 @@
     "nuxt-schema-org": "file:module.tgz",
     "nuxt": "~4.2.0",
     "@unhead/vue": "^2.0.7",
-    "unhead": "^2.0.7",
-    "@unhead/schema-org": "^2.1.13"
+    "unhead": "^2.0.7"
   },
   "devDependencies": {
     "@nuxt/test-utils": "^4.0.3",

--- a/test/compat-v2/render.test.ts
+++ b/test/compat-v2/render.test.ts
@@ -3,10 +3,13 @@ import { $fetch, setup } from '@nuxt/test-utils'
 import { load } from 'cheerio'
 import { describe, expect, it } from 'vitest'
 
-// Guards Unhead v2 compatibility: this fixture installs a coherent v2 stack
-// (Nuxt 4.2 / @unhead/vue@2 / @unhead/schema-org@2). It verifies the module's
-// cross-major code paths (feature-detected plugin, defineX identity, and the
-// computed-ref node handling) all resolve correctly against unhead v2 core.
+// Guards Unhead v2 compatibility AND regression #114: this fixture installs a v2
+// host (Nuxt 4.2 / @unhead/vue@2 / unhead@2) but does NOT pin @unhead/schema-org,
+// so the module's own (hoisted v3) copy is present. Without the major-aligning
+// alias, head resolution crashes with "Cannot read properties of undefined
+// (reading 'potentialAction')" and the route 500s. A successful graph render
+// proves the alias forced the v2 schema-org copy, and exercises the module's
+// cross-major paths (feature-detected plugin, defineX identity, computed-ref).
 await setup({
   rootDir: resolve(import.meta.dirname),
   server: true,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #114

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`v6.1.0` crashes a blank Nuxt 4.4.7 app on render with `Cannot read properties of undefined (reading 'potentialAction')`. Root cause is a version skew: `@unhead/schema-org` attaches an object `_resolver` to every graph node, and unhead **v3**'s `walkResolver` skips that key while **v2**'s walks into it and invokes the resolver's `resolve()` as an argument-less thunk. A fresh Nuxt 4.4.7 ships unhead v2, but npm auto-installs the `@unhead/schema-org` peer at latest (v3), producing the broken pairing. Verified in isolation: schema-org v3 + unhead v2 crashes; schema-org v2 + unhead v2 renders correctly.

Fix: vendor both majors and alias `@unhead/schema-org` to the one matching the host's unhead.

- `@unhead/schema-org` moves from `peerDependencies` to a direct dependency (canonical v3), plus a new `@unhead/schema-org-v2` npm alias (`@unhead/schema-org@^2`). Consumers no longer resolve the peer themselves.
- `src/unhead-compat.ts` detects the host unhead major (via `@unhead/vue`, falling back to `unhead`) and returns the matching vendor specifiers.
- `src/module.ts` aliases `@unhead/schema-org` to the v2 copy on a v2 host for both the bundler (`nuxt.options.alias`) and **nitro** (the SSR crash site), and loads its own build-time `defineWebPage` / auto-imports from the matching major.

### Regression coverage (the gap that let this ship)

The `test/compat-v2` fixture existed but **was never run in CI**, and it pinned `@unhead/schema-org@2` so it couldn't reproduce the skew anyway. This PR:

- Rewrites the fixture to drop the schema-org pin, so the module's own hoisted v3 copy is present on a v2 host — the exact #114 condition. The install in CI now has `@unhead/schema-org@3.1.3` present yet renders the full graph, proving the alias forced v2.
- Adds a dedicated `compat-v2` job to `.github/workflows/test.yml` that builds, packs, and installs the module into the isolated unhead v2 host. The main suite runs on unhead v3 and cannot catch this class of bug.