### PR TITLE
fix: detect host unhead major from nuxt's location under pnpm

### DIFF
--- a/src/unhead-compat.ts
+++ b/src/unhead-compat.ts
@@ -1,4 +1,4 @@
-import { readPackageJSON } from 'pkg-types'
+import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 
 export type UnheadMajor = 2 | 3
 
@@ -16,20 +16,36 @@ export type UnheadMajor = 2 | 3
  * module's primary major (3) when it can't be resolved.
  */
 export async function resolveHostUnheadMajor(rootDir: string): Promise<UnheadMajor> {
-  const url = rootDir.endsWith('/') ? rootDir : `${rootDir}/`
+  const rootUrl = rootDir.endsWith('/') ? rootDir : `${rootDir}/`
+  // Search roots for the host's unhead. Under pnpm's strict (non-hoisted) layout
+  // `@unhead/vue`/`unhead` are transitive deps of `nuxt` and are NOT resolvable
+  // from the project root, so detection would always miss and fall back to the
+  // default major (#114). Also search from `nuxt`'s install location, where the
+  // host's unhead is always reachable.
+  const searchUrls = [rootUrl]
+  const nuxtJson = await resolvePackageJSON('nuxt', { url: rootUrl }).catch(() => {
+    // a missing `nuxt` is an expected miss (e.g. a non-standard layout); we just
+    // keep searching from the project root only.
+    return undefined
+  })
+  if (nuxtJson)
+    searchUrls.push(nuxtJson.replace(/[^/\\]+$/, ''))
   // `@unhead/vue` is what schema-org actually peer-depends on; fall back to the
   // core `unhead` package when it isn't directly resolvable.
   for (const id of ['@unhead/vue', 'unhead']) {
-    const version = await readPackageJSON(id, { url }).then(pkg => pkg.version).catch(() => {
-      // an unresolvable package is an expected miss (it just isn't installed under
-      // this id); fall through to the next candidate, then the default major.
-      return undefined
-    })
-    const major = version ? Number.parseInt(version, 10) : Number.NaN
-    if (major === 2)
-      return 2
-    if (Number.isFinite(major) && major >= 3)
-      return 3
+    for (const url of searchUrls) {
+      const version = await readPackageJSON(id, { url }).then(pkg => pkg.version).catch(() => {
+        // an unresolvable package is an expected miss (not installed under this id
+        // at this search root); fall through to the next candidate/root, then the
+        // default major.
+        return undefined
+      })
+      const major = version ? Number.parseInt(version, 10) : Number.NaN
+      if (major === 2)
+        return 2
+      if (Number.isFinite(major) && major >= 3)
+        return 3
+    }
   }
   return 3
 }


### PR DESCRIPTION
## Problem

A fresh `@nuxtjs/seo@5.1.3` + `nuxt@4.4.2` install on **pnpm** returns a hard 500 on every page:

```
TypeError: Cannot read properties of undefined (reading 'potentialAction')
  at webSiteResolver  (walked by unhead v2's walkResolver)
```

This is the crash #114 set out to fix by vendoring both schema-org majors and selecting the one matching the host unhead. That selection never engaged here.

## Root cause

`resolveHostUnheadMajor` resolved `@unhead/vue`/`unhead` package.json **from the project root**. Under pnpm's strict (non-hoisted) layout those packages are transitive deps of `nuxt` and are not present at the project root, so both lookups fail and the function returns its default major `3`. The host actually renders with unhead `2`, so the v3 schema-org resolvers get walked by unhead v2 and crash. (npm hoists `@unhead/vue` to the root, which is why this was masked there.)

Confirmed with `pkg-types` against the repro: `@unhead/vue` from the project root → `ERR_MODULE_NOT_FOUND`; from `nuxt`'s directory → `2.1.15`.

## Fix

Also search from `nuxt`'s install location (resolved via `resolvePackageJSON('nuxt', …)`), where the host's `@unhead/vue` is always reachable.

## Verification

Built and linked into a pnpm `@nuxtjs/seo@5.1.3` + `nuxt@4.4.2` repro:
- `Detected unhead v2, aliasing @unhead/schema-org -> @unhead/schema-org-v2` now prints
- the `"SchemaOrgUnheadPlugin" is not exported` build warning is gone
- HTTP status **500 → 200**, schema-org `ld+json` (incl. `potentialAction`) renders correctly

Refs #114