### PR TITLE
fix: serialize schema org identity config

### DIFF
--- a/devtools/app.vue
+++ b/devtools/app.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { fetchGlobalDebug, isProductionMode, loadShiki, navigateTo, refreshSources, useRoute } from '#imports'
 import { computed, watch } from 'vue'
+import { fetchGlobalDebug, isProductionMode, loadShiki, navigateTo, refreshSources, useRoute } from '#imports'
 import { schemaOrgGraph } from './composables/rpc'
 
 await loadShiki()

--- a/devtools/composables/rpc.ts
+++ b/devtools/composables/rpc.ts
@@ -1,6 +1,6 @@
 import type { VueHeadClient } from '@unhead/vue/types'
-import { refreshSources, useDevtoolsConnection } from '#imports'
 import { ref } from 'vue'
+import { refreshSources, useDevtoolsConnection } from '#imports'
 
 export const hostHead = ref<VueHeadClient>()
 export const schemaOrgGraph = ref<any>(null)

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
 import { readPackageJSON } from 'pkg-types'
 import { setupDevToolsUI } from './devtools'
 import { extendTypes, resolveNuxtContentVersion } from './kit'
-import { resolveHostUnheadMajor, schemaOrgVendor } from './unhead-compat'
+import { resolveHostUnheadMajor, resolveSerializableIdentityConfig, schemaOrgVendor } from './unhead-compat'
 
 type SchemaOrgScriptAttributes = Partial<Script> & Record<string, unknown>
 
@@ -138,7 +138,7 @@ export default defineNuxtModule<ModuleOptions>({
       reactive: config.reactive,
       minify: config.minify,
       scriptAttributes: config.scriptAttributes,
-      identity: config.identity,
+      identity: resolveSerializableIdentityConfig(config.identity),
       version: version!,
     }
     // avoid polluting client-side bundle if we don't need to

--- a/src/runtime/app/plugins/defaults.ts
+++ b/src/runtime/app/plugins/defaults.ts
@@ -1,7 +1,7 @@
-import { useSiteConfig } from '#site-config/app/composables/useSiteConfig'
 import { defineWebPage, defineWebSite } from '@unhead/schema-org/vue'
 import { defineNuxtPlugin, useError } from 'nuxt/app'
 import { toValue } from 'vue'
+import { useSiteConfig } from '#site-config/app/composables/useSiteConfig'
 import { useSchemaOrg } from '../composables/useSchemaOrg'
 import { maybeAddIdentitySchemaOrg } from '../utils/shared'
 

--- a/src/runtime/app/plugins/i18n/defaults.ts
+++ b/src/runtime/app/plugins/i18n/defaults.ts
@@ -1,12 +1,12 @@
-// @ts-expect-error untyped
-import { useLocalePath } from '#i18n'
-import { useSiteConfig } from '#site-config/app/composables/useSiteConfig'
-import { createSitePathResolver } from '#site-config/app/composables/utils'
 import { defineWebPage, defineWebSite } from '@unhead/schema-org/vue'
 import { resolveSitePath } from 'nuxt-site-config/urls'
 import { defineNuxtPlugin, useError, useRuntimeConfig } from 'nuxt/app'
 import { hasProtocol, withHttps } from 'ufo'
 import { toValue } from 'vue'
+// @ts-expect-error untyped
+import { useLocalePath } from '#i18n'
+import { useSiteConfig } from '#site-config/app/composables/useSiteConfig'
+import { createSitePathResolver } from '#site-config/app/composables/utils'
 import { useSchemaOrg } from '../../composables/useSchemaOrg'
 import { maybeAddIdentitySchemaOrg } from '../../utils/shared'
 

--- a/src/runtime/server/routes/__schema-org__/debug.ts
+++ b/src/runtime/server/routes/__schema-org__/debug.ts
@@ -1,6 +1,6 @@
+import { defineEventHandler } from 'h3'
 import { getNitroOrigin } from '#site-config/server/composables/getNitroOrigin'
 import { getSiteConfig } from '#site-config/server/composables/getSiteConfig'
-import { defineEventHandler } from 'h3'
 import { useSchemaOrgConfig } from '../../utils/config'
 
 export default defineEventHandler(async (e) => {

--- a/src/runtime/server/utils/config.ts
+++ b/src/runtime/server/utils/config.ts
@@ -1,5 +1,5 @@
-import type { ModuleRuntimeConfig } from '#schema-org/types'
 import type { H3Event } from 'h3'
+import type { ModuleRuntimeConfig } from '#schema-org/types'
 import { defu } from 'defu'
 import { useRuntimeConfig } from 'nitropack/runtime'
 

--- a/src/unhead-compat.ts
+++ b/src/unhead-compat.ts
@@ -1,6 +1,54 @@
+import { dirname } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 
 export type UnheadMajor = 2 | 3
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function cloneSerializableIdentityValue(value: unknown): unknown {
+  if (typeof value === 'function')
+    return undefined
+  if (Array.isArray(value))
+    return value.map(cloneSerializableIdentityValue).filter(value => typeof value !== 'undefined')
+  if (!isPlainObject(value))
+    return value
+
+  const result: Record<string, any> = {}
+  for (const [key, child] of Object.entries(value)) {
+    if (key === '_resolver')
+      continue
+    const cloned = cloneSerializableIdentityValue(child)
+    if (typeof cloned !== 'undefined')
+      result[key] = cloned
+  }
+  return result
+}
+
+/**
+ * Nuxt validates runtime config serializability during prepare. `definePerson`,
+ * `defineOrganization`, etc. attach private `_resolver` methods to nodes, so
+ * config.identity must be reduced to public serializable data before it is
+ * copied into runtime config (#118).
+ */
+export function resolveSerializableIdentityConfig<T>(identity: T): T {
+  if (!isPlainObject(identity))
+    return identity
+
+  const identityNode = identity as Record<string, any>
+  const cloned = cloneSerializableIdentityValue(identityNode) as Record<string, any>
+  const resolverDefaults = isPlainObject(identityNode._resolver?.defaults) ? identityNode._resolver.defaults : {}
+  const resolvedType = Array.isArray(resolverDefaults['@type'])
+    ? resolverDefaults['@type'].at(-1)
+    : resolverDefaults['@type']
+
+  if (resolvedType && !cloned.type && !cloned['@type'])
+    cloned.type = resolvedType
+
+  return cloned as T
+}
 
 /**
  * `@unhead/schema-org` attaches an object `_resolver` to every graph node. Unhead
@@ -19,20 +67,21 @@ export type UnheadMajor = 2 | 3
  * it from `nuxtseo-shared/kit` and delete this local copy.
  */
 export async function resolveHostUnheadMajor(rootDir: string): Promise<UnheadMajor> {
-  const rootUrl = rootDir.endsWith('/') ? rootDir : `${rootDir}/`
-  // Search roots for the host's unhead. Under pnpm's strict (non-hoisted) layout
-  // `@unhead/vue`/`unhead` are transitive deps of `nuxt` and are NOT resolvable
-  // from the project root, so detection would always miss and fall back to the
-  // default major (#114). Also search from `nuxt`'s install location, where the
-  // host's unhead is always reachable.
-  const searchUrls = [rootUrl]
-  const nuxtJson = await resolvePackageJSON('nuxt', { url: rootUrl }).catch(() => {
-    // a missing `nuxt` is an expected miss (e.g. a non-standard layout); we just
-    // keep searching from the project root only.
-    return undefined
-  })
-  if (nuxtJson)
-    searchUrls.push(nuxtJson.replace(/[^/\\]+$/, ''))
+  const rootUrl = pathToFileURL(rootDir.endsWith('/') ? rootDir : `${rootDir}/`).href
+  // Search from the packages that own SSR before the app root. A host can have
+  // @unhead/vue v3 installed at the project root while Nuxt/Nitro renders with
+  // nested @unhead/vue v2; matching the root copy would still crash SSR (#114).
+  const searchUrls = []
+  for (const id of ['@nuxt/nitro-server', 'nuxt']) {
+    const pkgJson = await resolvePackageJSON(id, { url: rootUrl }).catch(() => {
+      // A missing package is an expected miss in non-standard layouts; keep
+      // searching from the remaining candidates.
+      return undefined
+    })
+    if (pkgJson)
+      searchUrls.push(`${dirname(pkgJson)}/`)
+  }
+  searchUrls.push(rootUrl)
   // `@unhead/vue` is what schema-org actually peer-depends on; fall back to the
   // core `unhead` package when it isn't directly resolvable.
   for (const id of ['@unhead/vue', 'unhead']) {

--- a/test/fixtures/config-identity/app.vue
+++ b/test/fixtures/config-identity/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Config identity fixture</div>
+</template>

--- a/test/fixtures/config-identity/nuxt.config.ts
+++ b/test/fixtures/config-identity/nuxt.config.ts
@@ -1,0 +1,23 @@
+import { defineNuxtConfig } from 'nuxt/config'
+import NuxtSchemaOrg from '../../../src/module'
+import { definePerson } from '../../../src/schema'
+
+export default defineNuxtConfig({
+  modules: [
+    NuxtSchemaOrg,
+  ],
+
+  site: {
+    url: 'https://nuxtseo.com',
+    name: 'Nuxt SEO',
+  },
+
+  schemaOrg: {
+    identity: definePerson({
+      name: 'Harlan',
+      jobTitle: 'Software Engineer',
+    }),
+  },
+
+  compatibilityDate: '2024-11-25',
+})

--- a/test/integration/config-identity.test.ts
+++ b/test/integration/config-identity.test.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path'
+import { setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+import { $fetchSchemaOrg } from './utils'
+
+await setup({
+  rootDir: resolve(import.meta.dirname, '../fixtures/config-identity'),
+  server: true,
+  browser: false,
+})
+
+describe('config identity', () => {
+  it('renders defineX identity config without resolver runtime config state', async () => {
+    const schema = await $fetchSchemaOrg('/')
+    const identity = schema['@graph'].find((node: any) => node['@id'] === 'https://nuxtseo.com/#identity')
+
+    expect(identity).toMatchObject({
+      '@type': 'Person',
+      'name': 'Harlan',
+      'jobTitle': 'Software Engineer',
+    })
+  })
+})

--- a/test/unit/unhead-compat.test.ts
+++ b/test/unit/unhead-compat.test.ts
@@ -1,0 +1,65 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { defineLocalBusiness, definePerson } from '@unhead/schema-org'
+import { describe, expect, it } from 'vitest'
+import { resolveHostUnheadMajor, resolveSerializableIdentityConfig } from '../../src/unhead-compat'
+
+function writePackage(root: string, id: string, version: string) {
+  const parts = id.split('/')
+  const packageDir = join(root, 'node_modules', ...parts)
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(join(packageDir, 'index.js'), '')
+  writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ name: id, version, main: './index.js' }))
+}
+
+describe('resolveSerializableIdentityConfig', () => {
+  it('removes private resolver functions from defineX identity config', () => {
+    const identity = resolveSerializableIdentityConfig(definePerson({
+      name: 'Harlan',
+      sameAs: ['https://github.com/harlan-zw'],
+    }))
+
+    expect(identity).toEqual({
+      type: 'Person',
+      name: 'Harlan',
+      sameAs: ['https://github.com/harlan-zw'],
+    })
+    expect(identity).not.toHaveProperty('_resolver')
+  })
+
+  it('uses the most specific resolver default type', () => {
+    const identity = resolveSerializableIdentityConfig(defineLocalBusiness({
+      name: 'Harlan Hamburgers',
+    }))
+
+    expect(identity).toEqual({
+      type: 'LocalBusiness',
+      name: 'Harlan Hamburgers',
+    })
+  })
+
+  it('does not mutate the original identity node', () => {
+    const identity = definePerson({ name: 'Harlan' })
+
+    resolveSerializableIdentityConfig(identity)
+
+    expect(identity._resolver?.resolve).toBeTypeOf('function')
+  })
+})
+
+describe('resolveHostUnheadMajor', () => {
+  it('prefers Nuxt Nitro server unhead over root-level unhead', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'nuxt-schema-org-unhead-'))
+
+    writePackage(root, '@unhead/vue', '3.1.3')
+    writePackage(root, 'unhead', '3.1.3')
+    writePackage(root, 'nuxt', '4.4.7')
+    writePackage(root, 'nuxt/node_modules/@unhead/vue', '2.1.15')
+    writePackage(root, '@nuxt/nitro-server', '4.4.7')
+    writePackage(root, '@nuxt/nitro-server/node_modules/@unhead/vue', '2.1.15')
+    writePackage(root, '@nuxt/nitro-server/node_modules/unhead', '2.1.15')
+
+    await expect(resolveHostUnheadMajor(root)).resolves.toBe(2)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #118

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`definePerson()`, `defineOrganization()`, and `defineLocalBusiness()` attach private Unhead resolver functions to identity nodes. This PR strips that private resolver state before copying `schemaOrg.identity` into Nuxt runtime config, while preserving the public payload and inferred identity type.

It also adds a regression fixture for docs-style `identity: definePerson(...)` config and covers the serializer with unit tests.