### PR TITLE
fix: prefer nitro unhead for schema-org vendor

### DIFF
--- a/src/unhead-compat.ts
+++ b/src/unhead-compat.ts
@@ -1,6 +1,15 @@
+import { dirname } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 
 export type UnheadMajor = 2 | 3
+
+function normalizePackageUrl(rootDir: string): string {
+  const url = rootDir.startsWith('file:')
+    ? rootDir
+    : pathToFileURL(rootDir.endsWith('/') ? rootDir : `${rootDir}/`).href
+  return url.endsWith('/') ? url : `${url}/`
+}
 
 /**
  * `@unhead/schema-org` attaches an object `_resolver` to every graph node. Unhead
@@ -19,20 +28,21 @@ export type UnheadMajor = 2 | 3
  * it from `nuxtseo-shared/kit` and delete this local copy.
  */
 export async function resolveHostUnheadMajor(rootDir: string): Promise<UnheadMajor> {
-  const rootUrl = rootDir.endsWith('/') ? rootDir : `${rootDir}/`
-  // Search roots for the host's unhead. Under pnpm's strict (non-hoisted) layout
-  // `@unhead/vue`/`unhead` are transitive deps of `nuxt` and are NOT resolvable
-  // from the project root, so detection would always miss and fall back to the
-  // default major (#114). Also search from `nuxt`'s install location, where the
-  // host's unhead is always reachable.
-  const searchUrls = [rootUrl]
-  const nuxtJson = await resolvePackageJSON('nuxt', { url: rootUrl }).catch(() => {
-    // a missing `nuxt` is an expected miss (e.g. a non-standard layout); we just
-    // keep searching from the project root only.
-    return undefined
-  })
-  if (nuxtJson)
-    searchUrls.push(nuxtJson.replace(/[^/\\]+$/, ''))
+  const rootUrl = normalizePackageUrl(rootDir)
+  // Search from the packages that own SSR before the app root. A host can have
+  // @unhead/vue v3 installed at the project root while Nuxt/Nitro renders with
+  // nested @unhead/vue v2; matching the root copy would still crash SSR (#114).
+  const searchUrls = []
+  for (const id of ['@nuxt/nitro-server', 'nuxt']) {
+    const pkgJson = await resolvePackageJSON(id, { url: rootUrl }).catch(() => {
+      // A missing package is an expected miss in non-standard layouts; keep
+      // searching from the remaining candidates.
+      return undefined
+    })
+    if (pkgJson)
+      searchUrls.push(`${dirname(pkgJson)}/`)
+  }
+  searchUrls.push(rootUrl)
   // `@unhead/vue` is what schema-org actually peer-depends on; fall back to the
   // core `unhead` package when it isn't directly resolvable.
   for (const id of ['@unhead/vue', 'unhead']) {

--- a/test/unit/unhead-compat.test.ts
+++ b/test/unit/unhead-compat.test.ts
@@ -1,0 +1,28 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { resolveHostUnheadMajor } from '../../src/unhead-compat'
+
+function writePackage(root: string, id: string, version: string) {
+  const packageDir = join(root, 'node_modules', ...id.split('/'))
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(join(packageDir, 'index.js'), '')
+  writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ name: id, version, main: './index.js' }))
+}
+
+describe('resolveHostUnheadMajor', () => {
+  it('prefers Nuxt Nitro server unhead over root-level unhead', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'nuxt-schema-org-unhead-'))
+
+    writePackage(root, '@unhead/vue', '3.1.3')
+    writePackage(root, 'unhead', '3.1.3')
+    writePackage(root, 'nuxt', '4.4.7')
+    writePackage(root, 'nuxt/node_modules/@unhead/vue', '2.1.15')
+    writePackage(root, '@nuxt/nitro-server', '4.4.7')
+    writePackage(root, '@nuxt/nitro-server/node_modules/@unhead/vue', '2.1.15')
+    writePackage(root, '@nuxt/nitro-server/node_modules/unhead', '2.1.15')
+
+    await expect(resolveHostUnheadMajor(root)).resolves.toBe(2)
+  })
+})


### PR DESCRIPTION
### Linked issue

Resolves #114
Related to harlan-zw/nuxt-seo#563

### Type of change

- [ ] Documentation
- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Chore
- [ ] Breaking change

### Description

`v6.1.2` still crashes in apps that install `@unhead/vue@3` at the project root while Nuxt/Nitro renders SSR with its nested Unhead v2 copy. The detector was checking root-level packages first, so it selected `@unhead/schema-org@3` even though the server render path needed the v2 vendor.

This matches the hardened helper merged in `nuxtseo-shared`: normalize package lookup roots to file URLs and prefer `@nuxt/nitro-server` / `nuxt` locations before the app root. The new unit test covers the mixed root-v3/Nitro-v2 dependency tree from the repro.

### Verification

- `pnpm dev:prepare`
- `pnpm vitest run test/unit/unhead-compat.test.ts`
- `pnpm test:compat-v2`
- `pnpm typecheck`
- `pnpm lint` passed with one existing devtools warning
