### PR TITLE
fix: inline v2 schema-org copy to survive prod dependency trace

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -126,9 +126,21 @@ export default defineNuxtModule<ModuleOptions>({
       // aliased v2 copy; substring replacement keeps subpaths like `/vue` intact.
       logger.debug(`Detected unhead v${unheadMajor}, aliasing @unhead/schema-org -> ${vendor.main}`)
       nuxt.options.alias['@unhead/schema-org'] = vendor.main
+      // `@unhead/schema-org-v2` is an npm alias (`npm:@unhead/schema-org@2`) whose
+      // installed package.json still carries `"name": "@unhead/schema-org"`. Left
+      // external, nitro's dependency trace collapses the alias dir onto the real
+      // package name, so the standalone `.output/server` never gets a
+      // `@unhead/schema-org-v2` dir and SSR crashes with ERR_MODULE_NOT_FOUND in
+      // slim images (works locally only via the project-root node_modules). See #116.
+      // Inline the v2 copy into both the client bundle and the nitro server bundle so
+      // no bare alias specifier survives to be resolved at runtime.
+      nuxt.options.build.transpile.push(vendor.main)
       nuxt.hooks.hook('nitro:config', (nitroConfig) => {
         nitroConfig.alias = nitroConfig.alias || {}
         nitroConfig.alias['@unhead/schema-org'] = vendor.main
+        nitroConfig.externals = nitroConfig.externals || {}
+        nitroConfig.externals.inline = nitroConfig.externals.inline || []
+        nitroConfig.externals.inline.push(vendor.main)
       })
     }
 

--- a/test/compat-v2/package.template.json
+++ b/test/compat-v2/package.template.json
@@ -4,7 +4,8 @@
   "type": "module",
   "description": "Isolated install on the Unhead v2 stack (Nuxt 4.2 / @unhead/vue@2 / unhead@2). It deliberately does NOT pin @unhead/schema-org: the module ships both majors and must alias to the v2 copy on a v2 host, otherwise its hoisted v3 copy crashes head resolution (#114). Copied to package.json by the `test:compat-v2` script and installed with npm, so it stays out of the pnpm workspace + catalog.",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "build": "nuxi build"
   },
   "dependencies": {
     "nuxt-schema-org": "file:module.tgz",

--- a/test/compat-v2/run.mjs
+++ b/test/compat-v2/run.mjs
@@ -6,7 +6,7 @@
 // into Nuxt/nitro module resolution and breaks the v2 build. Copying the fixture
 // to a temp dir with its own isolated install avoids that.
 import { execFileSync } from 'node:child_process'
-import { cpSync, mkdtempSync, readdirSync, renameSync } from 'node:fs'
+import { cpSync, existsSync, mkdtempSync, readdirSync, readFileSync, renameSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -33,3 +33,45 @@ run('npm', ['install', '--legacy-peer-deps', '--no-package-lock'], workDir)
 
 console.log('[compat-v2] running tests')
 run('npm', ['test'], workDir)
+
+// Regression #116: the render test above runs against the dev server, where the
+// node_modules fallback masks the bug. On a v2 host the module aliases
+// @unhead/schema-org to the npm-aliased @unhead/schema-org-v2, whose installed
+// package.json still carries `"name": "@unhead/schema-org"`. Left external, nitro's
+// dependency trace resolves the alias dir to its real package name and emits it
+// under @unhead/schema-org in the output node_modules, while the import statements
+// still reference @unhead/schema-org-v2. A slim production `.output/server` (no
+// project-root node_modules, e.g. a Docker image, especially under pnpm's symlinked
+// alias layout) then crashes with ERR_MODULE_NOT_FOUND. Run a real production build
+// and assert the v2 copy was inlined, so no bare alias specifier survives at all.
+//
+// NOTE: this harness installs with npm (flat node_modules), so the trace keeps the
+// @unhead/schema-org-v2 dir name and a no-fix build would still *run* here. The
+// assertion therefore checks the import was eliminated, not that the server boots.
+console.log('[compat-v2] building production output')
+run('npm', ['run', 'build'], workDir)
+
+const serverDir = join(workDir, '.output', 'server')
+if (!existsSync(serverDir))
+  throw new Error(`[compat-v2] ${serverDir} not found — production build did not emit a server bundle`)
+
+// matches the bare specifier and any subpath, e.g. `@unhead/schema-org-v2/vue`
+const externalImport = /(?:from|import|require)\s*(?:\(\s*)?['"]@unhead\/schema-org-v2(?:\/[^'"]*)?['"]/
+const offenders = []
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory())
+      walk(full)
+    else if (/\.[mc]?js$/.test(entry) && externalImport.test(readFileSync(full, 'utf8')))
+      offenders.push(full.slice(serverDir.length + 1))
+  }
+}
+walk(serverDir)
+
+if (offenders.length) {
+  throw new Error(
+    `[compat-v2] server chunks import @unhead/schema-org-v2 as an external (regression #116): ${offenders.join(', ')}`,
+  )
+}
+console.log('[compat-v2] ✓ @unhead/schema-org-v2 inlined into the server bundle')


### PR DESCRIPTION
### 🔗 Linked issue

Resolves harlan-zw/nuxt-seo-utils#116

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Production SSR crashes on a v2 host with `Cannot find package '@unhead/schema-org-v2'` (e.g. a slim Docker image).

On a v2 host the module aliases `@unhead/schema-org` to the npm-aliased `@unhead/schema-org-v2`, whose installed `package.json` still carries `"name": "@unhead/schema-org"`. Left external, nitro's dependency trace resolves the alias dir to its real package name and emits it under `@unhead/schema-org` in the output `node_modules`, while the chunks still `import ... from '@unhead/schema-org-v2/vue'`. The bare alias specifier then has nothing to resolve to and SSR 500s with `ERR_MODULE_NOT_FOUND`. It surfaces under pnpm's symlinked alias layout and in pruned production installs; a full local install masks it because the alias dir name survives the trace.

Fix: in the v2-alias branch, push `vendor.main` to `build.transpile` and `nitro.externals.inline` so the v2 schema-org copy (including the `/vue` subpath) is bundled into both the client and server output. No bare alias specifier survives to be resolved at runtime. The v3 path is unchanged.

Also extends the `compat-v2` harness with a real `nuxi build` step that walks `.output/server` and fails if any chunk still imports `@unhead/schema-org-v2` externally. Verified the assertion flags a no-fix build and passes with the fix.