### PR TITLE
perf(devtools): move nuxtseo-layer-devtools to dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@nuxt/kit": "catalog:",
     "defu": "catalog:",
     "nuxt-site-config": "catalog:",
-    "nuxtseo-layer-devtools": "catalog:",
     "nuxtseo-shared": "catalog:",
     "pkg-types": "catalog:",
     "ufo": "catalog:"
@@ -108,6 +107,7 @@
     "eslint-plugin-harlanzw": "catalog:",
     "happy-dom": "catalog:",
     "nuxt": "catalog:",
+    "nuxtseo-layer-devtools": "catalog:",
     "typescript": "catalog:",
     "unbuild": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ importers:
       nuxt-site-config:
         specifier: 'catalog:'
         version: 4.0.8(506f24af972dc32250931604d33c0301)
-      nuxtseo-layer-devtools:
-        specifier: 'catalog:'
-        version: 5.2.6(a8bcc49a514c6c2fceaec36f39baaaa8)
       nuxtseo-shared:
         specifier: 'catalog:'
         version: 5.2.6(93ffe7883099ab23c0fe8b4e4671596d)
@@ -197,6 +194,9 @@ importers:
       nuxt:
         specifier: 'catalog:'
         version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@parcel/watcher@2.5.6)(@types/node@25.9.2)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.10.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.16))(db0@0.3.4(better-sqlite3@12.10.0))(esbuild@0.28.0)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@8.0.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(yaml@2.9.0)
+      nuxtseo-layer-devtools:
+        specifier: 'catalog:'
+        version: 5.2.6(a8bcc49a514c6c2fceaec36f39baaaa8)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3


### PR DESCRIPTION
### 📚 Description

The devtools layer carries the dev-only UI build toolchain (`@nuxt/ui`, `shiki`, `tailwindcss`) as its own dependencies, so declaring `nuxtseo-layer-devtools` as a regular `dependency` pulled that ~170MB stack into production `node_modules`. It is only used to build the in-project DevTools client (Model C) in dev, so it belongs in `devDependencies` like the other Nuxt SEO modules already have it.

The assembler installs the layer on demand when a panel is opened (see harlan-zw/nuxt-seo#578), so nothing is lost at dev time.

Companion to harlan-zw/nuxt-seo#578.