### PR TITLE
fix: export schema-org v2 vue helpers

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,10 +26,10 @@ packages:
   - '!examples/**'
   - '!test/compat-v2/**'
 overrides:
-  vue: ^3.5.38
   '@unhead/vue': ^3.1.3
   unhead: ^3.1.3
   vite: npm:vite@8.0.1
+  vue: ^3.5.38
 catalog:
   '@antfu/eslint-config': ^9.0.0
   '@arethetypeswrong/cli': ^0.18.3

--- a/scripts/vendor-schema-org.mjs
+++ b/scripts/vendor-schema-org.mjs
@@ -5,7 +5,7 @@
 // Nuxt's unhead v2 tree invalid in `npm ls` (#125). The module aliases
 // `@unhead/schema-org` imports onto these files at app build time and inlines
 // them into the bundles, so they only need to exist inside this package.
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
@@ -23,6 +23,125 @@ const VENDORS = [
   { pkg: '@unhead/schema-org-v2', out: 'schema-org-v2' },
 ]
 
+const V2_VUE_EXTRA_RESOLVERS = [
+  ['defineDataset', 'dataset', 'Dataset'],
+  ['defineMusicAlbum', 'musicAlbum', 'MusicAlbum'],
+  ['defineMusicGroup', 'musicGroup', 'MusicGroup'],
+  ['defineMusicPlaylist', 'musicPlaylist', 'MusicPlaylist'],
+  ['defineMusicRecording', 'musicRecording', 'MusicRecording'],
+  ['definePodcastEpisode', 'podcastEpisode', 'PodcastEpisode'],
+  ['definePodcastSeason', 'podcastSeason', 'PodcastSeason'],
+  ['definePodcastSeries', 'podcastSeries', 'PodcastSeries'],
+  ['defineService', 'service', 'Service'],
+  ['defineTVEpisode', 'tvEpisode', 'TVEpisode'],
+  ['defineTVSeason', 'tvSeason', 'TVSeason'],
+  ['defineTVSeries', 'tvSeries', 'TVSeries'],
+]
+
+function exportedNames(code) {
+  const names = new Set()
+  for (const match of code.matchAll(/export\s*\{([^}]+)\}/g)) {
+    for (const rawName of match[1].split(',')) {
+      const name = rawName.trim()
+      if (!name)
+        continue
+      const alias = name.match(/\bas\s+([A-Za-z_$][\w$]*)$/)
+      names.add(alias ? alias[1] : name)
+    }
+  }
+  return names
+}
+
+function addToFinalExport(code, names) {
+  const exported = exportedNames(code)
+  const missing = names.filter(name => !exported.has(name))
+  if (!missing.length)
+    return code
+
+  const exportStart = code.lastIndexOf('\nexport { ')
+  if (exportStart === -1)
+    throw new Error('Could not find final export block in schema-org v2 vue entry.')
+  const listStart = exportStart + '\nexport { '.length
+  const listEnd = code.indexOf(' };', listStart)
+  if (listEnd === -1)
+    throw new Error('Could not find final export block end in schema-org v2 vue entry.')
+
+  const namesList = code.slice(listStart, listEnd).split(',').map(name => name.trim()).filter(Boolean)
+  return `${code.slice(0, listStart)}${[...namesList, ...missing].join(', ')}${code.slice(listEnd)}`
+}
+
+function patchSchemaOrgV2VueRuntime(outDir) {
+  const file = join(outDir, 'vue.mjs')
+  let code = readFileSync(file, 'utf8')
+  const missingResolvers = V2_VUE_EXTRA_RESOLVERS.filter(([name]) => !code.includes(`function ${name}(`))
+
+  if (missingResolvers.length) {
+    const resolverCode = missingResolvers.map(([name, resolver]) => `function ${name}(input) {
+  return provideResolver(input, "${resolver}");
+}`).join('\n')
+    const marker = 'function useSchemaOrg(input = [], options = {}) {'
+    if (!code.includes(marker))
+      throw new Error('Could not find useSchemaOrg marker in schema-org v2 vue runtime.')
+    code = code.replace(marker, `${resolverCode}\n${marker}`)
+  }
+
+  code = addToFinalExport(code, [
+    'UnheadSchemaOrg',
+    ...V2_VUE_EXTRA_RESOLVERS.map(([name]) => name),
+  ])
+
+  const exports = exportedNames(code)
+  const missingExports = ['UnheadSchemaOrg', ...V2_VUE_EXTRA_RESOLVERS.map(([name]) => name)]
+    .filter(name => !exports.has(name))
+  if (missingExports.length)
+    throw new Error(`schema-org v2 vue runtime is missing exports: ${missingExports.join(', ')}`)
+
+  writeFileSync(file, code)
+}
+
+function patchSchemaOrgV2VueTypes(outDir, entry) {
+  const file = join(outDir, entry)
+  let code = readFileSync(file, 'utf8')
+  const indexSpecifier = './index.mjs'
+  const typeNames = V2_VUE_EXTRA_RESOLVERS.map(([, , typeName]) => typeName)
+
+  if (!exportedNames(code).has('UnheadSchemaOrg'))
+    code = `export { UnheadSchemaOrg } from '${indexSpecifier}';\n${code}`
+
+  const typeImport = `import type { ${typeNames.join(', ')} } from '${indexSpecifier}';`
+  if (!code.includes(typeImport))
+    code = code.replace('import { ComponentResolver } from \'unplugin-vue-components\';', `${typeImport}\nimport { ComponentResolver } from 'unplugin-vue-components';`)
+
+  const missingResolvers = V2_VUE_EXTRA_RESOLVERS.filter(([name]) => !code.includes(`declare function ${name}<`))
+  if (missingResolvers.length) {
+    const declarations = missingResolvers.map(([name, , typeName]) => `declare function ${name}<T extends Record<string, any>>(input?: DeepResolvableProperties<${typeName} & T>): DeepResolvableProperties<${typeName} & T>;`).join('\n')
+    const marker = 'declare function defineSoftwareApp'
+    if (!code.includes(marker))
+      throw new Error(`Could not find defineSoftwareApp marker in schema-org v2 vue types ${entry}.`)
+    code = code.replace(marker, `${declarations}\n${marker}`)
+  }
+
+  code = addToFinalExport(code, V2_VUE_EXTRA_RESOLVERS.map(([name]) => name))
+
+  const exports = exportedNames(code)
+  const missingExports = ['UnheadSchemaOrg', ...V2_VUE_EXTRA_RESOLVERS.map(([name]) => name)]
+    .filter(name => !exports.has(name))
+  if (missingExports.length)
+    throw new Error(`schema-org v2 vue types ${entry} are missing exports: ${missingExports.join(', ')}`)
+
+  writeFileSync(file, code)
+}
+
+function patchSchemaOrgV2Vue(outDir) {
+  // @unhead/schema-org v2 advertises the v3-era define* helpers in
+  // schemaOrgAutoImports, but its /vue entry forgot to export them. Nuxt imports
+  // every advertised helper from the source, so the copied v2 entry must be
+  // self-consistent for Unhead v2 hosts (#129).
+  patchSchemaOrgV2VueRuntime(outDir)
+  patchSchemaOrgV2VueTypes(outDir, 'vue.d.ts')
+  patchSchemaOrgV2VueTypes(outDir, 'vue.d.mts')
+}
+
 rmSync(vendorRoot, { recursive: true, force: true })
 
 for (const { pkg, out } of VENDORS) {
@@ -38,6 +157,8 @@ for (const { pkg, out } of VENDORS) {
       cpSync(src, join(outDir, entry), { recursive: true })
   }
   cpSync(join(pkgDir, 'LICENSE'), join(outDir, 'LICENSE'))
+  if (out === 'schema-org-v2')
+    patchSchemaOrgV2Vue(outDir)
   // traceability only. Deliberately NOT a package.json: a nested manifest
   // carrying the real package name is what broke nitro's dependency trace (#116).
   writeFileSync(join(outDir, 'vendor.json'), `${JSON.stringify({ name: '@unhead/schema-org', version }, null, 2)}\n`)

--- a/test/compat-v2/app.vue
+++ b/test/compat-v2/app.vue
@@ -8,6 +8,9 @@ useSchemaOrg(computed(() => [
     headline: 'Hello v2',
     description: 'computed-ref article on the unhead v2 stack',
   }),
+  defineDataset({
+    name: 'Compat dataset',
+  }),
 ]))
 </script>
 

--- a/test/compat-v2/render.test.ts
+++ b/test/compat-v2/render.test.ts
@@ -40,6 +40,11 @@ describe('unhead v2 compatibility', () => {
     const article = graph.find(n => n['@type'] === 'Article')
     expect(article?.headline).toBe('Hello v2')
 
+    // regression #129: v2 auto-imports advertise defineDataset and other v3-era
+    // helpers, so the vendored v2 /vue entry must export and resolve them.
+    const dataset = graph.find(n => n['@type'] === 'Dataset')
+    expect(dataset?.name).toBe('Compat dataset')
+
     // no junk/unresolved nodes leaked into the graph
     expect(graph.some(n => String(n['@id']).includes('#/schema//'))).toBe(false)
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #129

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@unhead/schema-org` v2 lists helpers like `defineDataset` in `schemaOrgAutoImports`, but its `/vue` entry does not export them. The vendor build now patches the copied v2 Vue runtime and declarations so Nuxt auto-imports resolve on Unhead v2 hosts, with a compat fixture covering `defineDataset`.