### PR TITLE
chore: code cleanup sweep

### DIFF
--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1,1 +1,2 @@
-export { extendTypes, resolveNuxtContentVersion } from 'nuxtseo-shared/kit'
+export { extendTypes, resolveHostUnheadMajor, resolveNuxtContentVersion } from 'nuxtseo-shared/kit'
+export type { UnheadMajor } from 'nuxtseo-shared/kit'

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,8 +18,9 @@ import { defu } from 'defu'
 import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
 import { readPackageJSON } from 'pkg-types'
 import { setupDevToolsUI } from './devtools'
-import { extendTypes, resolveNuxtContentVersion } from './kit'
-import { resolveHostUnheadMajor, resolveSerializableIdentityConfig, schemaOrgVendor } from './unhead-compat'
+import { extendTypes, resolveHostUnheadMajor, resolveNuxtContentVersion } from './kit'
+import { buildSchemaOrgContentScript } from './runtime/utils/content'
+import { resolveSerializableIdentityConfig, schemaOrgVendor } from './unhead-compat'
 
 type SchemaOrgScriptAttributes = Partial<Script> & Record<string, unknown>
 
@@ -209,28 +210,7 @@ export default defineNuxtModule<ModuleOptions>({
           return
         }
         const content = ctx.content
-        const nodes = Array.isArray(content.schemaOrg) ? content.schemaOrg : [defineWebPage(content.schemaOrg)]
-
-        // we need to recursively go through all nodes and swap `type` for `@type`
-        const replaceType = (node: any) => {
-          if (node.type) {
-            node['@type'] = node.type
-            delete node.type
-          }
-          Object.entries(node).forEach(([, value]) => {
-            if (typeof value === 'object') {
-              replaceType(value)
-            }
-          })
-          return node
-        }
-
-        const script = {
-          type: 'application/ld+json',
-          key: 'schema-org-graph',
-          nodes: nodes.map(replaceType),
-          ...(config.scriptAttributes || {}),
-        } as Script & { nodes: any }
+        const script = buildSchemaOrgContentScript(content.schemaOrg, defineWebPage, config.scriptAttributes) as Script & { nodes: any }
 
         content.head = defu(<UseHeadInput<any>> { script: [script] }, content.head)
         ctx.content = content

--- a/src/runtime/app/composables/useSchemaOrg.ts
+++ b/src/runtime/app/composables/useSchemaOrg.ts
@@ -33,19 +33,9 @@ export function useSchemaOrg<T extends Input>(input: T): ActiveHeadEntry<UseHead
     tagPriority: 'high',
     ...config.scriptAttributes,
   }
-  // simple usage for dev
-  if (import.meta.dev) {
-    return useHead({
-      script: [script],
-    })
-  }
-  if (import.meta.server) {
-    // we don't need to use the direct composable as the plugin is already registered
-    return useHead({
-      script: [script],
-    })
-  }
-  else if (config?.reactive) {
+  // dev always needs it for the overlay; server doesn't need the direct
+  // composable as the plugin is already registered; client only when reactive
+  if (import.meta.dev || import.meta.server || config?.reactive) {
     return useHead({
       script: [script],
     })

--- a/src/runtime/server/plugins/nuxt-content-v2.ts
+++ b/src/runtime/server/plugins/nuxt-content-v2.ts
@@ -5,6 +5,7 @@ import type { UnheadAugmentation } from '../../types'
 import { defineWebPage } from '@unhead/schema-org/vue'
 import { defu } from 'defu'
 import { defineNitroPlugin } from 'nitropack/runtime'
+import { buildSchemaOrgContentScript } from '../../utils/content'
 import { useSchemaOrgConfig } from '../utils/config'
 
 export default defineNitroPlugin((nitroApp) => {
@@ -17,28 +18,7 @@ export default defineNitroPlugin((nitroApp) => {
     if (!content.schemaOrg) {
       return
     }
-    const nodes = Array.isArray(content.schemaOrg) ? content.schemaOrg : [defineWebPage(content.schemaOrg)]
-
-    // we need to recursively go through all nodes and swap `type` for `@type`
-    const replaceType = (node: any) => {
-      if (node.type) {
-        node['@type'] = node.type
-        delete node.type
-      }
-      Object.entries(node).forEach(([, value]) => {
-        if (typeof value === 'object') {
-          replaceType(value)
-        }
-      })
-      return node
-    }
-
-    const script = {
-      type: 'application/ld+json',
-      key: 'schema-org-graph',
-      nodes: nodes.map(replaceType),
-      ...(config.scriptAttributes || {}),
-    } as Script & UnheadAugmentation<any>['script']
+    const script = buildSchemaOrgContentScript(content.schemaOrg, defineWebPage, config.scriptAttributes) as Script & UnheadAugmentation<any>['script']
 
     content.head = defu(<UseHeadInput<any>> {
       script: [script],

--- a/src/runtime/utils/content.ts
+++ b/src/runtime/utils/content.ts
@@ -1,0 +1,24 @@
+export function buildSchemaOrgContentScript(schemaOrgInput: unknown, defineWebPage: (input?: any) => any, scriptAttributes?: Record<string, unknown> | false) {
+  const nodes = Array.isArray(schemaOrgInput) ? schemaOrgInput : [defineWebPage(schemaOrgInput)]
+
+  // we need to recursively go through all nodes and swap `type` for `@type`
+  const replaceType = (node: any) => {
+    if (node.type) {
+      node['@type'] = node.type
+      delete node.type
+    }
+    Object.entries(node).forEach(([, value]) => {
+      if (typeof value === 'object') {
+        replaceType(value)
+      }
+    })
+    return node
+  }
+
+  return {
+    type: 'application/ld+json',
+    key: 'schema-org-graph',
+    nodes: nodes.map(replaceType),
+    ...(scriptAttributes || {}),
+  }
+}

--- a/src/unhead-compat.ts
+++ b/src/unhead-compat.ts
@@ -1,9 +1,7 @@
+import type { UnheadMajor } from './kit'
 import { existsSync } from 'node:fs'
-import { dirname } from 'node:path'
-import { pathToFileURL } from 'node:url'
-import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 
-export type UnheadMajor = 2 | 3
+export type { UnheadMajor } from './kit'
 
 function isPlainObject(value: unknown): value is Record<string, any> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -49,65 +47,6 @@ export function resolveSerializableIdentityConfig<T>(identity: T): T {
     cloned.type = resolvedType
 
   return cloned as T
-}
-
-function normalizePackageUrl(rootDir: string): string {
-  const url = rootDir.startsWith('file:')
-    ? rootDir
-    : pathToFileURL(rootDir.endsWith('/') ? rootDir : `${rootDir}/`).href
-  return url.endsWith('/') ? url : `${url}/`
-}
-
-/**
- * `@unhead/schema-org` attaches an object `_resolver` to every graph node. Unhead
- * v3's `walkResolver` skips that key, but v2's walks into it and invokes the
- * resolver's `resolve()` method as an argument-less thunk, crashing with
- * "Cannot read properties of undefined (reading 'potentialAction')" (#114).
- *
- * Empirically schema-org v2 renders cleanly on unhead v2, and schema-org v3 on
- * unhead v3. So we ship both majors (`@unhead/schema-org` + the aliased
- * `@unhead/schema-org-v2`) and select the one matching the host's unhead.
- *
- * Returns the major of the unhead the host app renders with, falling back to the
- * module's primary major (3) when it can't be resolved.
- *
- * TODO: once nuxtseo-shared ships `resolveHostUnheadMajor` (nuxt-seo#561), import
- * it from `nuxtseo-shared/kit` and delete this local copy.
- */
-export async function resolveHostUnheadMajor(rootDir: string): Promise<UnheadMajor> {
-  const rootUrl = normalizePackageUrl(rootDir)
-  // Search from the packages that own SSR before the app root. A host can have
-  // @unhead/vue v3 installed at the project root while Nuxt/Nitro renders with
-  // nested @unhead/vue v2; matching the root copy would still crash SSR (#114).
-  const searchUrls = []
-  for (const id of ['@nuxt/nitro-server', 'nuxt']) {
-    const pkgJson = await resolvePackageJSON(id, { url: rootUrl }).catch(() => {
-      // A missing package is an expected miss in non-standard layouts; keep
-      // searching from the remaining candidates.
-      return undefined
-    })
-    if (pkgJson)
-      searchUrls.push(`${dirname(pkgJson)}/`)
-  }
-  searchUrls.push(rootUrl)
-  // `@unhead/vue` is what schema-org actually peer-depends on; fall back to the
-  // core `unhead` package when it isn't directly resolvable.
-  for (const id of ['@unhead/vue', 'unhead']) {
-    for (const url of searchUrls) {
-      const version = await readPackageJSON(id, { url }).then(pkg => pkg.version).catch(() => {
-        // an unresolvable package is an expected miss (not installed under this id
-        // at this search root); fall through to the next candidate/root, then the
-        // default major.
-        return undefined
-      })
-      const major = version ? Number.parseInt(version, 10) : Number.NaN
-      if (major === 2)
-        return 2
-      if (Number.isFinite(major) && major >= 3)
-        return 3
-    }
-  }
-  return 3
 }
 
 export type SchemaOrgVendor

--- a/test/unit/unhead-compat.test.ts
+++ b/test/unit/unhead-compat.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { defineLocalBusiness, definePerson } from '@unhead/schema-org'
 import { describe, expect, it } from 'vitest'
-import { resolveHostUnheadMajor, resolveSerializableIdentityConfig } from '../../src/unhead-compat'
+import { resolveHostUnheadMajor } from '../../src/kit'
+import { resolveSerializableIdentityConfig } from '../../src/unhead-compat'
 
 function writePackage(root: string, id: string, version: string) {
   const packageDir = join(root, 'node_modules', ...id.split('/'))


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Dead code and duplication cleanup, no behavior or public API changes.

- `unhead-compat.ts` carried a `resolveHostUnheadMajor` copy with a TODO to drop it once `nuxtseo-shared/kit` shipped the same function (it now has, byte-identical logic). Swapped the local copy for the shared one, re-exported from `kit.ts` alongside the module's other `nuxtseo-shared/kit` re-exports.
- `module.ts`'s `content:file:afterParse` hook (Nuxt Content v3) and `runtime/server/plugins/nuxt-content-v2.ts` (v2) each had their own copy of the `type` → `@type` node-walking + script-building logic. Extracted into `runtime/utils/content.ts#buildSchemaOrgContentScript`, shared by both.
- `useSchemaOrg()` had three branches (`dev`, `server`, `client && reactive`) that all called `useHead()` with the identical payload. Collapsed to one condition.

Net: -85 LOC. Verified with `pnpm lint`, `pnpm typecheck`, and `pnpm test` (all green; one flaky content e2e failure under full-suite load turned out to be pre-existing resource contention, not a regression — confirmed by re-running in isolation and re-running the full suite).