### PR TITLE
fix: avoid undefined schema plugin import

### DIFF
--- a/src/runtime/app/utils/shared.ts
+++ b/src/runtime/app/utils/shared.ts
@@ -1,9 +1,5 @@
 import type { MetaInput as _MetaInput, MetaInput } from '@unhead/schema-org/vue'
 import type { NuxtApp } from 'nuxt/app'
-// namespace import so the plugin export can be feature-detected across majors:
-// unhead-schema-org v2 exports `SchemaOrgUnheadPlugin`, v3 renamed it to
-// `UnheadSchemaOrg` (same signature). A static named import of either name
-// would fail to link against the other major.
 import * as schemaOrgVue from '@unhead/schema-org/vue'
 import { resolveSitePath } from 'nuxt-site-config/urls'
 import { useRoute, useRuntimeConfig } from 'nuxt/app'
@@ -16,6 +12,12 @@ import {
 import { createSitePathResolver } from '#site-config/app/composables/utils'
 import { useSchemaOrg } from '../composables/useSchemaOrg'
 import { useSchemaOrgConfig } from './config'
+
+type SchemaOrgPlugin = (
+  config: _MetaInput,
+  resolveMeta: () => Promise<_MetaInput>,
+  options: NonNullable<Parameters<typeof schemaOrgVue.UnheadSchemaOrg>[2]>,
+) => ReturnType<typeof schemaOrgVue.UnheadSchemaOrg>
 
 function resolvePathDirect(siteConfig: Record<string, any>, path: string, options: { absolute?: boolean, withBase?: boolean, canonical?: boolean }) {
   const nuxtBase = useRuntimeConfig().app.baseURL || '/'
@@ -82,9 +84,9 @@ export function initSchemaOrgHead(nuxtApp: NuxtApp) {
   const head = injectHead()
   const config = useSchemaOrgConfig()
   const siteConfig = useSiteConfig()
-  const SchemaOrgPlugin = schemaOrgVue.UnheadSchemaOrg ?? (schemaOrgVue as any).SchemaOrgUnheadPlugin
+  const schemaOrgPlugin = schemaOrgVue.UnheadSchemaOrg as SchemaOrgPlugin
   head.use(
-    SchemaOrgPlugin({} as _MetaInput, async () => {
+    schemaOrgPlugin({} as _MetaInput, async () => {
       const meta = {} as MetaInput
       // call hook
       await nuxtApp.hooks.callHook('schema-org:meta', meta)

--- a/test/unit/build-warnings.test.ts
+++ b/test/unit/build-warnings.test.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const vitestPackage = require.resolve('vitest/package.json')
+const requireFromVitest = createRequire(join(dirname(vitestPackage), 'index.js'))
+const vitePackage = requireFromVitest.resolve('vite/package.json')
+const requireFromVite = createRequire(join(dirname(vitePackage), 'index.js'))
+const rolldownPackage = requireFromVite.resolve('rolldown/package.json')
+const rolldownBin = join(dirname(rolldownPackage), 'bin/cli.mjs')
+
+describe('runtime build warnings', () => {
+  it('only reads exports provided by the v3 schema org runtime', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nuxt-schema-org-build-'))
+    const source = readFileSync(new URL('../../src/runtime/app/utils/shared.ts', import.meta.url), 'utf8')
+      .replaceAll('@unhead/schema-org/vue', './schema-org-vue.mjs')
+      .replace('../composables/useSchemaOrg', 'useSchemaOrg')
+      .replace('./config', 'schemaOrgConfig')
+
+    writeFileSync(join(root, 'shared.ts'), source)
+    writeFileSync(join(root, 'schema-org-vue.mjs'), `
+export const UnheadSchemaOrg = () => {}
+export const defineOrganization = () => {}
+export const definePerson = () => {}
+export const defineLocalBusiness = () => {}
+`)
+
+    const result = spawnSync(process.execPath, [
+      rolldownBin,
+      join(root, 'shared.ts'),
+      '--file',
+      join(root, 'shared.mjs'),
+      '--format',
+      'esm',
+      '--external',
+      [
+        'nuxt/app',
+        'nuxt-site-config/urls',
+        'ufo',
+        'vue',
+        '#imports',
+        '#site-config/app/composables/useSiteConfig',
+        '#site-config/app/composables/utils',
+        'useSchemaOrg',
+        'schemaOrgConfig',
+      ].join(','),
+    ], {
+      encoding: 'utf8',
+    })
+
+    rmSync(root, { recursive: true, force: true })
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stderr).not.toContain('IMPORT_IS_UNDEFINED')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #140

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Remove the legacy `SchemaOrgUnheadPlugin` fallback because both vendored runtimes expose `UnheadSchemaOrg`. Add a Rolldown regression test that bundles the runtime against the v3 export surface and fails on `IMPORT_IS_UNDEFINED`.
