### PR TITLE
chore: avoid `__dirname` in shipped devtools layer config

### DIFF
--- a/devtools/nuxt.config.ts
+++ b/devtools/nuxt.config.ts
@@ -1,7 +1,10 @@
+import { fileURLToPath } from 'node:url'
 import { resolve } from 'pathe'
+
+const currentDir = fileURLToPath(new URL('.', import.meta.url))
 
 // Nuxt SEO devtools panel, shipped as a layer (Model C). Components flat-registered
 // so intra-panel references resolve by name.
 export default defineNuxtConfig({
-  components: [{ path: resolve(__dirname, './components'), pathPrefix: false }],
+  components: [{ path: resolve(currentDir, './components'), pathPrefix: false }],
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

cjs globals have been polyfilled by jiti for a while but these aren't guaranteed to exist in the future

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
