### PR TITLE
feat: first-party comark-content support

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -18,6 +18,7 @@ export default defineBuildConfig({
     'std-env',
     'nitropack',
     'consola',
+    '@harlan-zw/comark-content',
     '@nuxt/content',
     'zod',
     '@unhead/vue',

--- a/docs/content/2.guides/1.content.md
+++ b/docs/content/2.guides/1.content.md
@@ -48,6 +48,36 @@ useSeoMeta(page.value.seo || {})
 </script>
 ```
 
+## Setup comark-content
+
+[comark-content](https://github.com/harlan-zw/harlan-nuxt/tree/main/packages/comark-content) is a Markdown-only content module. Nuxt Schema.org supports it first-party.
+
+No schema opt in is needed. Write the `schemaOrg` key in frontmatter.
+
+```md [content/about.md]
+---
+title: About
+schemaOrg:
+  "@type": "AboutPage"
+---
+
+hello
+```
+
+Render the tags with `useHead()`{lang="ts"} and the `head` key, the same as with Nuxt Content v3.
+
+```vue [[...slug].vue]
+<script setup lang="ts">
+const route = useRoute()
+const { data: page } = await useAsyncData(`page-${route.path}`, () => {
+  return queryCollection('content').path(route.path).first()
+})
+// Ensure the schema.org is rendered
+useHead(page.value?.head || {})
+useSeoMeta(page.value?.seo || {})
+</script>
+```
+
 ## Setup Nuxt Content v2
 
 No extra set up is required, simply add the `schemaOrg` key to your frontmatter.

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
     "@arethetypeswrong/cli": "catalog:",
-    "@iconify-json/lucide": "catalog:",
     "@harlan-zw/comark-content": "catalog:",
+    "@iconify-json/lucide": "catalog:",
     "@nuxt/content": "catalog:",
     "@nuxt/module-builder": "catalog:",
     "@nuxt/schema": "catalog:",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@antfu/eslint-config": "catalog:",
     "@arethetypeswrong/cli": "catalog:",
     "@iconify-json/lucide": "catalog:",
+    "@harlan-zw/comark-content": "catalog:",
     "@nuxt/content": "catalog:",
     "@nuxt/module-builder": "catalog:",
     "@nuxt/schema": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@arethetypeswrong/cli':
       specifier: ^0.18.5
       version: 0.18.5
+    '@harlan-zw/comark-content':
+      specifier: ^0.1.3
+      version: 0.1.3
     '@iconify-json/lucide':
       specifier: ^1.2.122
       version: 1.2.122
@@ -144,6 +147,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.5
+      '@harlan-zw/comark-content':
+        specifier: 'catalog:'
+        version: 0.1.3(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(shiki@4.4.2)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
       '@iconify-json/lucide':
         specifier: 'catalog:'
         version: 1.2.122
@@ -1096,6 +1102,13 @@ packages:
 
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
+
+  '@harlan-zw/comark-content@0.1.3':
+    resolution: {integrity: sha512-nmGSQjp8lqLHFenlKXg/7mB8p82Gw0spp8Jr3aSvaHpyxQwqS3enDE+IxrnouH15bCjRQeZab+v7uWDWPWpNGA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      nuxt: '>=4.5.0 <5.0.0'
+      vue: ^3.5.41
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3050,8 +3063,14 @@ packages:
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -3889,6 +3908,23 @@ packages:
   colortranslator@5.0.0:
     resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
 
+  comark@0.6.2:
+    resolution: {integrity: sha512-hlWa7KlGPfRxovQavnHZlLlTUKrfwE7/o4ewCY0FzqFtRvVT8VdslrumQwELIiK9utsurpoSWCBFj1yVMtDOtw==}
+    peerDependencies:
+      beautiful-mermaid: ^1.1.3
+      katex: ^0.17.0
+      rangi: ^2.2.0
+      shiki: ^4.3.1
+    peerDependenciesMeta:
+      beautiful-mermaid:
+        optional: true
+      katex:
+        optional: true
+      rangi:
+        optional: true
+      shiki:
+        optional: true
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -4175,15 +4211,31 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-prop@10.2.0:
     resolution: {integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==}
@@ -4985,6 +5037,10 @@ packages:
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -5212,6 +5268,10 @@ packages:
 
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  js-yaml@5.3.0:
+    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
     hasBin: true
 
   jsdoc-type-pratt-parser@7.3.0:
@@ -5445,6 +5505,9 @@ packages:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
@@ -5513,6 +5576,9 @@ packages:
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
     engines: {node: '>=18'}
+
+  markdown-exit@1.1.0-beta.2:
+    resolution: {integrity: sha512-8CzMGVlFZ4DEfnc8KU+4ycUW2SIOuiXqCHD7z51ecVEi/weyc0f2ylQbCm4KoKuVlTZSuMUMnWT0hTyquZ7anQ==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -5587,6 +5653,9 @@ packages:
 
   mdn-data@2.29.0:
     resolution: {integrity: sha512-pVxQFCcaYUEAH853+v7yoI/qzhxXSq1bTb9obMYGYAN1c3Hen+XDCEvr296XhstrwlSTNgOR7mCSD4JPjbJe5A==}
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -6583,6 +6652,10 @@ packages:
   protocols@2.0.2:
     resolution: {integrity: sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -6606,6 +6679,10 @@ packages:
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
+
+  rangi@2.2.0:
+    resolution: {integrity: sha512-zMXLNs+3ejB2dg5kjJdNbllNq6FrdtEbHA9f3POxbSIHb0CyslALbY8qSDCE2r+/6Ku7xaVHKtnC5qHbF2SgNg==}
+    hasBin: true
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -7248,6 +7325,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -8738,6 +8818,23 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@harlan-zw/comark-content@0.1.3(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(shiki@4.4.2)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))
+      comark: 0.6.2(rangi@2.2.0)(shiki@4.4.2)
+      nuxt: 4.5.2(de917305003d35b881988cf8f911efc2)
+      rangi: 2.2.0
+      vue: 3.5.41(typescript@6.0.3)
+    transitivePeerDependencies:
+      - beautiful-mermaid
+      - katex
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - shiki
+      - unplugin
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -11072,9 +11169,13 @@ snapshots:
 
   '@types/katex@0.16.8': {}
 
+  '@types/linkify-it@5.0.0': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
 
@@ -12056,6 +12157,16 @@ snapshots:
 
   colortranslator@5.0.0: {}
 
+  comark@0.6.2(rangi@2.2.0)(shiki@4.4.2):
+    dependencies:
+      entities: 8.0.0
+      htmlparser2: 12.0.0
+      js-yaml: 5.3.0
+      markdown-exit: 1.1.0-beta.2
+    optionalDependencies:
+      rangi: 2.2.0
+      shiki: 4.4.2
+
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
@@ -12339,17 +12450,35 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dot-prop@10.2.0:
     dependencies:
@@ -13380,6 +13509,13 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -13594,6 +13730,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@5.3.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsdoc-type-pratt-parser@7.3.0: {}
 
   jsdoc-type-pratt-parser@8.0.0: {}
@@ -13764,6 +13904,10 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   linkifyjs@4.3.3: {}
 
   listhen@1.10.1(srvx@0.11.22):
@@ -13865,6 +14009,16 @@ snapshots:
       p-event: 6.0.1
       type-fest: 4.41.0
       web-worker: 1.5.0
+
+  markdown-exit@1.1.0-beta.2:
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+      entities: 7.0.1
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -14027,6 +14181,8 @@ snapshots:
   mdn-data@2.27.1: {}
 
   mdn-data@2.29.0: {}
+
+  mdurl@2.1.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -15578,6 +15734,8 @@ snapshots:
 
   protocols@2.0.2: {}
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -15591,6 +15749,8 @@ snapshots:
   radix3@1.1.2: {}
 
   range-parser@1.3.0: {}
+
+  rangi@2.2.0: {}
 
   rc9@3.0.1:
     dependencies:
@@ -16406,6 +16566,8 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: ^5.3.12
       version: 5.3.12
     nuxtseo-shared:
-      specifier: ^5.3.12
-      version: 5.3.12
+      specifier: ^5.3.14
+      version: 5.3.14
     pkg-types:
       specifier: ^2.3.1
       version: 2.3.1
@@ -127,7 +127,7 @@ importers:
         version: 4.2.1(@nuxt/schema@4.5.2)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(zod@4.4.3)
       nuxtseo-shared:
         specifier: 'catalog:'
-        version: 5.3.12(ff6ba1375dba7c9fb562f10d71fdaada)
+        version: 5.3.14(ff6ba1375dba7c9fb562f10d71fdaada)
       pkg-types:
         specifier: 'catalog:'
         version: 2.3.1
@@ -6022,6 +6022,20 @@ packages:
       zod:
         optional: true
 
+  nuxtseo-shared@5.3.14:
+    resolution: {integrity: sha512-kt3IrUILAD4ElsA5+3uroQUHmDLfQkiYWrdXm4Eb/tSm7L0ug2WQc6Okh9m/KtypCVBfwtChrAVMgSyT/VYP5w==}
+    peerDependencies:
+      '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt-site-config: ^3.2.0 || ^4.0.0
+      vue: ^3.5.41
+      zod: ^3.23.0 || ^4.0.0
+    peerDependenciesMeta:
+      nuxt-site-config:
+        optional: true
+      zod:
+        optional: true
+
   nypm@0.6.9:
     resolution: {integrity: sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==}
     engines: {node: '>=18'}
@@ -10189,7 +10203,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config: 4.2.1(@nuxt/schema@4.5.2)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.12(ff6ba1375dba7c9fb562f10d71fdaada)
+      nuxtseo-shared: 5.3.14(ff6ba1375dba7c9fb562f10d71fdaada)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -14704,7 +14718,7 @@ snapshots:
       image-size: 2.0.2
       nuxt: 4.5.2(de917305003d35b881988cf8f911efc2)
       nuxt-site-config: 4.2.1(@nuxt/schema@4.5.2)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(zod@4.4.3)
-      nuxtseo-shared: 5.3.12(ff6ba1375dba7c9fb562f10d71fdaada)
+      nuxtseo-shared: 5.3.14(ff6ba1375dba7c9fb562f10d71fdaada)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -14751,7 +14765,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config-kit: 4.2.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
-      nuxtseo-shared: 5.3.12(ff6ba1375dba7c9fb562f10d71fdaada)
+      nuxtseo-shared: 5.3.14(ff6ba1375dba7c9fb562f10d71fdaada)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.2.1(vue@3.5.41(typescript@6.0.3))
@@ -15013,6 +15027,36 @@ snapshots:
       - zod
 
   nuxtseo-shared@5.3.12(ff6ba1375dba7c9fb562f10d71fdaada):
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))
+      '@nuxt/schema': 4.5.2
+      birpc: 4.0.0
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt: 4.5.2(de917305003d35b881988cf8f911efc2)
+      nypm: 0.6.9
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sirv: 3.0.2
+      std-env: 4.2.0
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@6.0.3)
+    optionalDependencies:
+      nuxt-site-config: 4.2.1(@nuxt/schema@4.5.2)(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+
+  nuxtseo-shared@5.3.14(ff6ba1375dba7c9fb562f10d71fdaada):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: ^0.18.5
       version: 0.18.5
     '@harlan-zw/comark-content':
-      specifier: ^0.1.3
-      version: 0.1.3
+      specifier: ^0.1.4
+      version: 0.1.4
     '@iconify-json/lucide':
       specifier: ^1.2.122
       version: 1.2.122
@@ -149,7 +149,7 @@ importers:
         version: 0.18.5
       '@harlan-zw/comark-content':
         specifier: 'catalog:'
-        version: 0.1.3(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(shiki@4.4.2)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
+        version: 0.1.4(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(shiki@4.4.2)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
       '@iconify-json/lucide':
         specifier: 'catalog:'
         version: 1.2.122
@@ -1103,8 +1103,8 @@ packages:
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
-  '@harlan-zw/comark-content@0.1.3':
-    resolution: {integrity: sha512-nmGSQjp8lqLHFenlKXg/7mB8p82Gw0spp8Jr3aSvaHpyxQwqS3enDE+IxrnouH15bCjRQeZab+v7uWDWPWpNGA==}
+  '@harlan-zw/comark-content@0.1.4':
+    resolution: {integrity: sha512-OeGc0OOEjxwEKKjmjJdqC9a//EnFJORRvRXxvNCij5eSACaz2rxj3oK9h6/Rtg+1S05JNQe6lL1PERx+7AlbAw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       nuxt: '>=4.5.0 <5.0.0'
@@ -8833,7 +8833,7 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@harlan-zw/comark-content@0.1.3(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(shiki@4.4.2)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))':
+  '@harlan-zw/comark-content@0.1.4(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(de917305003d35b881988cf8f911efc2))(oxc-parser@0.141.0)(rolldown@1.2.1)(shiki@4.4.2)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.1)(unplugin@3.3.0(esbuild@0.27.7)(rolldown@1.2.1)(rollup@4.62.4)(vite@8.0.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))
       comark: 0.6.2(rangi@2.2.0)(shiki@4.4.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,8 +43,8 @@ overrides:
 catalog:
   '@antfu/eslint-config': ^9.3.0
   '@arethetypeswrong/cli': ^0.18.5
-  '@iconify-json/lucide': ^1.2.122
   '@harlan-zw/comark-content': ^0.1.3
+  '@iconify-json/lucide': ^1.2.122
   '@nuxt/content': ^3.15.2
   '@nuxt/kit': ^4.5.2
   '@nuxt/module-builder': ^1.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ minimumReleaseAgeExclude:
   - '@nuxt/vite-builder@4.5.0'
   - nuxt@4.5.0
   - nuxt-seo-utils@8.3.2
-  - '@harlan-zw/comark-content@0.1.3'
+  - '@harlan-zw/comark-content@0.1.4'
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -44,7 +44,7 @@ overrides:
 catalog:
   '@antfu/eslint-config': ^9.3.0
   '@arethetypeswrong/cli': ^0.18.5
-  '@harlan-zw/comark-content': ^0.1.3
+  '@harlan-zw/comark-content': ^0.1.4
   '@iconify-json/lucide': ^1.2.122
   '@nuxt/content': ^3.15.2
   '@nuxt/kit': ^4.5.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -68,7 +68,7 @@ catalog:
   nuxt-seo-utils: ^8.3.3
   nuxt-site-config: ^4.2.1
   nuxtseo-layer-devtools: ^5.3.12
-  nuxtseo-shared: ^5.3.12
+  nuxtseo-shared: ^5.3.14
   pkg-types: ^2.3.1
   typescript: 6.0.3
   ufo: ^1.6.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,18 +18,16 @@ minimumReleaseAgeExclude:
   - '@vue/server-renderer@3.5.38'
   - '@vue/shared@3.5.38'
   - vue@3.5.38
-  - nuxt-site-config-kit@4.1.4
-  - nuxt-site-config-kit@4.2.1
-  - nuxt-site-config@4.1.4
-  - nuxt-site-config@4.2.1
-  - site-config-stack@4.1.4
-  - site-config-stack@4.2.1
+  - nuxt-site-config-kit@4.1.4 || 4.2.1
+  - nuxt-site-config@4.1.4 || 4.2.1
+  - site-config-stack@4.1.4 || 4.2.1
   - '@nuxt/kit@4.5.0'
   - '@nuxt/nitro-server@4.5.0'
   - '@nuxt/schema@4.5.0'
   - '@nuxt/vite-builder@4.5.0'
   - nuxt@4.5.0
   - nuxt-seo-utils@8.3.2
+  - '@harlan-zw/comark-content@0.1.3'
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -46,6 +44,7 @@ catalog:
   '@antfu/eslint-config': ^9.3.0
   '@arethetypeswrong/cli': ^0.18.5
   '@iconify-json/lucide': ^1.2.122
+  '@harlan-zw/comark-content': ^0.1.3
   '@nuxt/content': ^3.15.2
   '@nuxt/kit': ^4.5.2
   '@nuxt/module-builder': ^1.0.3

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -1,2 +1,3 @@
-export { extendTypes, resolveHostUnheadMajor, resolveNuxtContentVersion } from 'nuxtseo-shared/kit'
+export type { ContentProvider } from 'nuxtseo-shared/kit'
+export { extendTypes, hasContentFileHooks, resolveContentProvider, resolveHostUnheadMajor } from 'nuxtseo-shared/kit'
 export type { UnheadMajor } from 'nuxtseo-shared/kit'

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
 import { setupNitroRuntimeCompatibility, useModuleLogger } from 'nuxtseo-shared/kit'
 import { readPackageJSON } from 'pkg-types'
 import { setupDevToolsUI } from './devtools'
-import { extendTypes, resolveHostUnheadMajor, resolveNuxtContentVersion } from './kit'
+import { extendTypes, hasContentFileHooks, resolveContentProvider, resolveHostUnheadMajor } from './kit'
 import { buildSchemaOrgContentScript } from './runtime/utils/content'
 import { resolveSerializableIdentityConfig, schemaOrgVendor } from './unhead-compat'
 
@@ -86,6 +86,10 @@ export default defineNuxtModule<ModuleOptions>({
       },
       'nuxt-site-config': {
         version: '>=3.2',
+      },
+      '@harlan-zw/comark-content': {
+        version: '>=0.1.2',
+        optional: true,
       },
       '@nuxt/content': {
         version: '>=2',
@@ -201,10 +205,12 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.alias['#schema-org'] = resolve('./runtime')
 
-    const contentVersion = await resolveNuxtContentVersion()
-    const isNuxtContentV3 = contentVersion && contentVersion.version === 3
-    const isNuxtContentV2 = contentVersion && contentVersion.version === 2
-    if (isNuxtContentV3) {
+    const contentProvider = await resolveContentProvider(nuxt)
+    const isNuxtContentV2 = contentProvider._tag === 'NuxtContent' && contentProvider.version === 2
+    // @nuxt/content v3 and comark-content both fire this build hook with the same
+    // context shape, so one handler covers both. Nuxt Content v2 has no such hook and
+    // is served by a Nitro plugin instead.
+    if (hasContentFileHooks(contentProvider)) {
       nuxt.hooks.hook('content:file:afterParse', (ctx) => {
         if (typeof ctx.content.schemaOrg === 'undefined') {
           return

--- a/test/fixtures/comark-content/.nuxtrc
+++ b/test/fixtures/comark-content/.nuxtrc
@@ -1,0 +1,2 @@
+imports.autoImport=true
+typescript.includeWorkspace=true

--- a/test/fixtures/comark-content/app.vue
+++ b/test/fixtures/comark-content/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/fixtures/comark-content/content.config.ts
+++ b/test/fixtures/comark-content/content.config.ts
@@ -1,0 +1,16 @@
+import { dirname, resolve } from 'node:path'
+import { defineCollection, defineContentConfig } from '@harlan-zw/comark-content'
+
+const dirName = dirname(import.meta.url.replace('file://', ''))
+
+export default defineContentConfig({
+  collections: {
+    content: defineCollection({
+      type: 'page',
+      source: {
+        include: '**/*.md',
+        cwd: resolve(dirName, 'content'),
+      },
+    }),
+  },
+})

--- a/test/fixtures/comark-content/content/about.md
+++ b/test/fixtures/comark-content/content/about.md
@@ -1,0 +1,7 @@
+---
+title: About
+schemaOrg:
+  "@type": "AboutPage"
+---
+
+hello

--- a/test/fixtures/comark-content/content/index.md
+++ b/test/fixtures/comark-content/content/index.md
@@ -1,0 +1,10 @@
+---
+title: Home
+schemaOrg:
+  - "@type": "Person"
+    name: "John Doe"
+  - "@type": "Organization"
+    name: "Example Inc."
+---
+
+# bar

--- a/test/fixtures/comark-content/content/question-answer.md
+++ b/test/fixtures/comark-content/content/question-answer.md
@@ -1,0 +1,18 @@
+---
+title: FAQ
+schemaOrg:
+  "@type": FaqPage
+  mainEntity:
+    - "@type": "Question"
+      name: "What is your return policy?"
+      acceptedAnswer:
+        "@type": "Answer"
+        text: "You can return any item within 30 days of purchase."
+    - "@type": "Question"
+      name: "Do you offer technical support?"
+      acceptedAnswer:
+        "@type": "Answer"
+        text: "Yes, we offer 24/7 technical support."
+---
+
+hello

--- a/test/fixtures/comark-content/nuxt.config.ts
+++ b/test/fixtures/comark-content/nuxt.config.ts
@@ -1,0 +1,17 @@
+import NuxtSchemaOrg from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    NuxtSchemaOrg,
+    '@harlan-zw/comark-content',
+  ],
+
+  site: {
+    url: 'https://nuxtseo.com',
+    name: 'nuxt-schema-org',
+    description: 'The quickest and easiest way to build Schema.org graphs for Nuxt.',
+  },
+
+  devtools: { enabled: true },
+  compatibilityDate: '2024-09-11',
+})

--- a/test/fixtures/comark-content/pages/[...slug].vue
+++ b/test/fixtures/comark-content/pages/[...slug].vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { queryCollection, useRoute } from '#imports'
+
+const route = useRoute()
+const { data: page } = await useAsyncData(`page-${route.path}`, () => {
+  return queryCollection('content').path(route.path).first()
+})
+useSeoMeta({
+  title: page.value?.seo?.title || 'Nuxt Schema.org',
+  description: page.value?.seo?.description || 'The quickest and easiest way to build Schema.org graphs for Nuxt.',
+})
+useHead(page.value?.head || {})
+</script>
+
+<template>
+  <div>
+    <ContentRenderer
+      v-if="page"
+      :value="page"
+    />
+    <div v-else>
+      Page not found
+    </div>
+  </div>
+</template>

--- a/test/integration/comark-content.test.ts
+++ b/test/integration/comark-content.test.ts
@@ -1,0 +1,43 @@
+import { resolve } from 'node:path'
+import { setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+import { $fetchSchemaOrg } from './utils'
+
+await setup({
+  rootDir: resolve(import.meta.dirname, '../fixtures/comark-content'),
+  server: true,
+  browser: false,
+})
+
+describe('comark-content', () => {
+  it('renders the schemaOrg frontmatter into the graph', async () => {
+    const schema = await $fetchSchemaOrg('/about')
+    expect(schema).toMatchInlineSnapshot(`
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@id": "https://nuxtseo.com/#website",
+            "@type": "WebSite",
+            "description": "The quickest and easiest way to build Schema.org graphs for Nuxt.",
+            "name": "nuxt-schema-org",
+            "url": "https://nuxtseo.com/",
+          },
+          {
+            "@id": "https://nuxtseo.com/about#webpage",
+            "@type": [
+              "AboutPage",
+              "AboutPage",
+            ],
+            "description": "The quickest and easiest way to build Schema.org graphs for Nuxt.",
+            "isPartOf": {
+              "@id": "https://nuxtseo.com/#website",
+            },
+            "name": "About",
+            "url": "https://nuxtseo.com/about",
+          },
+        ],
+      }
+    `)
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

The `schemaOrg` frontmatter mapping gated on `resolveNuxtContentVersion()`, which only answers for `@nuxt/content`. An app running [comark-content](https://github.com/harlan-zw/harlan-nuxt/tree/main/packages/comark-content) got no graph from its Markdown and no hint as to why.

`hasContentFileHooks(provider)` gates it now. Both `@nuxt/content` v3 and comark fire `content:file:afterParse` with the same context shape, so the handler that builds the `defineWebPage` script and merges it into `content.head` is unchanged, it just runs for either provider. Nuxt Content v2 still goes through the Nitro plugin, since it has no such hook.

Rendering is still on the page: `useHead(page.head)` in the catch-all, same as before.

One thing worth knowing before you look at the new snapshot: `/about` resolves `@type` to `["AboutPage", "AboutPage"]`. I checked the `@nuxt/content` v3 fixture against the same page and it does exactly the same, so it is not something comark introduced. Looks like the frontmatter type gets merged onto the resolved webpage node twice somewhere in the graph build. Left alone here, it deserves its own fix.

Depends on `nuxtseo-shared` exporting `resolveContentProvider()`. CI is red until that publishes.


### 🔗 Related

Six PRs for one cross-repo change. Release order is top to bottom:

1. nuxt-seo `nuxtseo-shared` https://github.com/harlan-zw/nuxt-seo/pull/621
2. `@nuxtjs/sitemap` https://github.com/nuxt-modules/sitemap/pull/665
3. `@nuxtjs/robots` https://github.com/nuxt-modules/robots/pull/321
4. `nuxt-schema-org` https://github.com/harlan-zw/nuxt-schema-org/pull/151
5. `nuxt-link-checker` https://github.com/harlan-zw/nuxt-link-checker/pull/104
6. `comark-content` https://github.com/harlan-zw/harlan-nuxt/pull/74

2 through 5 need 1 published. 6 needs 2 published.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).