### PR TITLE
fix: pass nuxtApp to injectHead in init plugin

### DIFF
--- a/src/runtime/app/utils/shared.ts
+++ b/src/runtime/app/utils/shared.ts
@@ -81,7 +81,7 @@ export function initSchemaOrgMeta() {
 }
 
 export function initSchemaOrgHead(nuxtApp: NuxtApp) {
-  const head = injectHead()
+  const head = injectHead(nuxtApp)
   const config = useSchemaOrgConfig()
   const siteConfig = useSiteConfig()
   const schemaOrgPlugin = schemaOrgVue.UnheadSchemaOrg as SchemaOrgPlugin


### PR DESCRIPTION
### What happens

`initSchemaOrgHead()` can throw an opaque error at plugin setup:

```
TypeError: undefined is not an object (evaluating 'head.use')
// Chromium: Cannot read properties of undefined (reading 'use')
```

### Why

`src/runtime/app/utils/shared.ts` already receives the `nuxtApp` (both `plugins/init.ts` and `plugins/i18n/init.ts` pass it), but it calls `injectHead()` with no argument:

```ts
export function initSchemaOrgHead(nuxtApp: NuxtApp) {
  const head = injectHead()
  ...
  head.use(schemaOrgPlugin(...))
}
```

Nuxt's `injectHead` resolves the app itself and can return `undefined`:

```ts
// nuxt/dist/head/runtime/composables.js
function injectHead(nuxtApp) {
  const nuxt = nuxtApp || useNuxtApp()
  return nuxt.ssrContext?.head || nuxt.runWithContext(() => {
    if (hasInjectionContext()) {
      const head = inject(headSymbol)
      if (!head) throw unheadDiagnostics.NUXT_E6001()
      return head
    }
  })
}
```

When there is no Vue injection context at the moment the plugin runs, the `runWithContext` callback falls off the end and returns `undefined`. `head.use(...)` is then called unguarded, so the failure surfaces as a `TypeError` on `head` instead of anything pointing at Nuxt/unhead.

### The fix

Pass the `nuxtApp` the function already holds:

```diff
-  const head = injectHead()
+  const head = injectHead(nuxtApp)
```

`injectHead(nuxtApp?: NuxtApp)` has accepted the optional argument for the whole supported range (module `compatibility.nuxt` is `>=3.16.0`), so this is a one-line change with no behaviour difference on the happy path — when an app is resolvable, `nuxtApp || useNuxtApp()` already yields the same instance. It only makes resolution deterministic when the ambient context is not available.

No guard was added: sibling modules (`nuxt-seo-utils`, `@nuxtjs/robots`) all call `injectHead()` unguarded, so a throw-with-message here would be out of style. Happy to add one if you prefer.

### How it surfaced

Hit in dev on Nuxt 4 when Vite re-optimised deps mid-request (`504 Outdated Optimize Dep`) and part of the module graph was stale, so the schema-org plugin ran outside a usable injection context.

### Verification

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test --run` — 9 files, 20 tests passed

